### PR TITLE
fix(file-history): ensure file items not truncated by slice limit

### DIFF
--- a/src/vscode-based-ide-utility.ts
+++ b/src/vscode-based-ide-utility.ts
@@ -81,13 +81,15 @@ export const readVSCodeBasedIDEState = (): VSWindowModel[] => {
   // console.log('IDE state:', jsonData);
 
   if (jsonData.entries) {
-    // Include fileUri entries now for file history support
-    // and limit to 100
-    jsonData.entries = jsonData.entries
-      .filter((entry: VSCodeBasedEntry) => {
-        return entry.folderUri || entry.workspace || entry.fileUri;
-      })
+    // Separate folders/workspaces and files to ensure file items
+    // are always included regardless of how many folders exist
+    const foldersAndWorkspaces = jsonData.entries
+      .filter((entry: VSCodeBasedEntry) => entry.folderUri || entry.workspace)
       .slice(0, 100);
+    const files = jsonData.entries
+      .filter((entry: VSCodeBasedEntry) => entry.fileUri)
+      .slice(0, 50);
+    jsonData.entries = [...foldersAndWorkspaces, ...files];
   }
 
   const resp = convertVSCodeBasedSqliteToVSWindowModelArray(jsonData);


### PR DESCRIPTION
## Summary
- Fix file history items not appearing in the switcher list
- Root cause: VS Code's SQLite stores folder entries before file entries. The previous `.slice(0, 100)` truncated all `fileUri` entries when there were 100+ folders
- Solution: Split into separate slices — folders/workspaces (max 100) and files (max 50) — then combine, ensuring file items always appear at the bottom of the list

## Test plan
- [ ] `yarn start` and verify both folder and file items appear in the switcher
- [ ] Confirm file items are listed after folder/workspace items
- [ ] `yarn make` and verify the packaged app shows file items

_🤖 On behalf of @grimmerk — generated with Claude Code_
