### PR TITLE
feat: add CI workflow for notarized DMG builds

### DIFF
--- a/.github/workflows/notarize.yml
+++ b/.github/workflows/notarize.yml
@@ -1,0 +1,93 @@
+name: Build, Sign & Notarize (non-MAS)
+
+on:
+  workflow_dispatch:
+    inputs:
+      create_release:
+        description: 'Create a GitHub Release with the DMG'
+        type: boolean
+        default: true
+      release_tag:
+        description: 'Release tag (e.g. v1.0.33). Leave empty to auto-generate from package.json'
+        type: string
+        default: ''
+
+jobs:
+  build-and-notarize:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Import certificate to keychain
+        env:
+          APPLE_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          CERTIFICATE_PATH=$RUNNER_TEMP/certificate.p12
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
+
+          echo -n "$APPLE_CERTIFICATE_P12_BASE64" | base64 --decode -o $CERTIFICATE_PATH
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+
+          security import $CERTIFICATE_PATH -P "$APPLE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH
+
+          # Import Developer ID G2 intermediate certificate
+          curl -sO https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer
+          security import DeveloperIDG2CA.cer -k $KEYCHAIN_PATH
+          rm DeveloperIDG2CA.cer
+
+      - name: Build app
+        run: yarn make
+
+      - name: Install create-dmg
+        run: brew install create-dmg
+
+      - name: Sign, notarize, and create DMG
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: sh ./sign-notarize.sh
+
+      - name: Get version from package.json
+        id: version
+        run: echo "version=$(node -p 'require("./package.json").version')" >> $GITHUB_OUTPUT
+
+      - name: Upload DMG artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: CodeV-${{ steps.version.outputs.version }}.dmg
+          path: ./out/CodeV.dmg
+
+      - name: Create GitHub Release
+        if: ${{ inputs.create_release }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ inputs.release_tag }}"
+          if [ -z "$TAG" ]; then
+            TAG="v${{ steps.version.outputs.version }}"
+          fi
+          gh release create "$TAG" ./out/CodeV.dmg \
+            --title "$TAG" \
+            --notes "Non-App Store notarized build"
+
+      - name: Cleanup keychain
+        if: always()
+        run: security delete-keychain $RUNNER_TEMP/app-signing.keychain-db || true

--- a/sign-notarize.sh
+++ b/sign-notarize.sh
@@ -2,7 +2,7 @@
 # Sign and notarize CodeV for non-App Store distribution
 # Prerequisites:
 #   1. "Developer ID Application" certificate in Keychain
-#   2. .env file with APPLE_ID, APPLE_APP_PASSWORD, APPLE_TEAM_ID
+#   2. Environment variables or .env file: APPLE_ID, APPLE_APP_PASSWORD, APPLE_TEAM_ID
 
 set -e
 
@@ -12,7 +12,7 @@ if [ -f .env ]; then
 fi
 
 if [ -z "$APPLE_ID" ] || [ -z "$APPLE_APP_PASSWORD" ] || [ -z "$APPLE_TEAM_ID" ]; then
-  echo "Error: Missing APPLE_ID, APPLE_APP_PASSWORD, or APPLE_TEAM_ID in .env"
+  echo "Error: Missing APPLE_ID, APPLE_APP_PASSWORD, or APPLE_TEAM_ID in environment or .env"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow (`notarize.yml`) for building, signing, notarizing, and releasing CodeV DMG
- Triggered via `workflow_dispatch` with optional release tag input
- Reuses `sign-notarize.sh` for consistency between local and CI builds
- Auto-reads version from `package.json` if no tag specified
- Uploads DMG as artifact and optionally creates a GitHub Release

## GitHub Secrets required
- `APPLE_CERTIFICATE_P12_BASE64` — Developer ID Application .p12 (base64)
- `APPLE_CERTIFICATE_PASSWORD` — .p12 password
- `APPLE_ID` — Apple ID email
- `APPLE_APP_PASSWORD` — App-specific password
- `APPLE_TEAM_ID` — Team ID

## Test plan
- [ ] Trigger workflow_dispatch manually from Actions tab
- [ ] Verify DMG artifact is uploaded
- [ ] Verify GitHub Release is created with correct tag
- [ ] Download DMG and verify notarization on a different Mac

_🤖 On behalf of @grimmerk — generated with Claude Code_
