### PR TITLE
fix: ignore duplicate intermediate cert import in CI

### DIFF
--- a/.github/workflows/notarize.yml
+++ b/.github/workflows/notarize.yml
@@ -49,7 +49,7 @@ jobs:
 
           # Import Developer ID G2 intermediate certificate
           curl -sO https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer
-          security import DeveloperIDG2CA.cer -k $KEYCHAIN_PATH
+          security import DeveloperIDG2CA.cer -k $KEYCHAIN_PATH || true
           rm DeveloperIDG2CA.cer
 
       - name: Build app


### PR DESCRIPTION
## Summary
- Fix CI failure: ignore duplicate intermediate certificate import error (`|| true`)

## Context
macOS CI runner already has `DeveloperIDG2CA.cer` installed, causing `security import` to fail with "The specified item already exists in the keychain".

_🤖 On behalf of @grimmerk — generated with Claude Code_
