### PR TITLE
fix: detect multiple active sessions with same cwd

### DIFF
--- a/src/claude-session-utility.ts
+++ b/src/claude-session-utility.ts
@@ -212,6 +212,8 @@ export const detectActiveSessions = async (): Promise<Map<string, number>> => {
     });
 
   const activeMap = new Map<string, number>();
+  // Track which session IDs are already claimed to avoid duplicate assignment
+  const claimedSessionIds = new Set<string>();
 
   try {
     const output = await execPromise(
@@ -223,6 +225,8 @@ export const detectActiveSessions = async (): Promise<Map<string, number>> => {
       return activeMap;
     }
 
+    // First pass: handle processes with explicit --resume <id>
+    const cwdProcesses: { pid: number; line: string }[] = [];
     for (const line of output.split('\n')) {
       if (!line.trim()) continue;
 
@@ -233,19 +237,28 @@ export const detectActiveSessions = async (): Promise<Map<string, number>> => {
       const resumeMatch = line.match(/--resume\s+([a-f0-9-]{36})/);
       if (resumeMatch) {
         activeMap.set(resumeMatch[1], pid);
+        claimedSessionIds.add(resumeMatch[1]);
         continue;
       }
 
       if (line.includes('claude')) {
-        const cwdOutput = await execPromise(`lsof -p ${pid} -Fn 2>/dev/null | grep "^n/" | head -1`);
-        const cwdMatch = cwdOutput.match(/^n(.+)$/m);
-        if (cwdMatch) {
-          const cwd = cwdMatch[1];
-          const allSessions = readClaudeSessions(500);
-          const match = allSessions.find((s) => s.project === cwd);
-          if (match) {
-            activeMap.set(match.sessionId, pid);
-          }
+        cwdProcesses.push({ pid, line });
+      }
+    }
+
+    // Second pass: handle claude -r processes (no explicit session ID)
+    // Use lsof to find cwd, then match to unclaimed sessions
+    const allSessions = readClaudeSessions(500);
+    for (const { pid } of cwdProcesses) {
+      const cwdOutput = await execPromise(`lsof -p ${pid} -Fn 2>/dev/null | grep "^n/" | head -1`);
+      const cwdMatch = cwdOutput.match(/^n(.+)$/m);
+      if (cwdMatch) {
+        const cwd = cwdMatch[1];
+        // Find the first unclaimed session with this cwd
+        const match = allSessions.find((s) => s.project === cwd && !claimedSessionIds.has(s.sessionId));
+        if (match) {
+          activeMap.set(match.sessionId, pid);
+          claimedSessionIds.add(match.sessionId);
         }
       }
     }


### PR DESCRIPTION
## Summary

Fix detection of multiple active sessions with the same working directory.

### Before
Two `claude -r` processes in the same cwd → only one session gets purple dot. The other is treated as non-active, clicking it opens a new terminal window.

### After
Both sessions get purple dots. Each process is assigned to a different (unclaimed) session via `claimedSessionIds` tracking.

### Known Limitation
When multiple `claude -r` (no explicit session ID) processes share the same cwd, the PID-to-session mapping may be incorrect — process A could be assigned session B's ID and vice versa. This means iTerm2 tty matching may switch to the wrong tab.

This only happens with `claude -r` (no `--resume <uuid>`). Sessions started with explicit `--resume <uuid>` are always correctly mapped.

Root cause: there is no way to externally determine which session a `claude -r` process belongs to without PID/tty exposed by the terminal's AppleScript API.

### Upstream Issues to Watch

Per-terminal PID/tty in AppleScript would fully solve this for both detection and switching:

| Issue | Terminal | Title | Status |
|-------|----------|-------|--------|
| ghostty-org/ghostty#11592 | Ghostty | `macOS: Add pid and tty properties to AppleScript terminal class` | Open |
| ghostty-org/ghostty#10756 | Ghostty | `macOS: Expose TTY, PID on TerminalEntity within App Shortcuts` | Open |
| ghostty-org/ghostty#11354 | Ghostty | `appintents: expose PID and TTY on TerminalEntity` | **PR Open** — implementation in progress |
| ghostty-org/ghostty#10606 | Ghostty | Discussion: AppleScript automation capabilities | Open |
| manaflow-ai/cmux#1826 | cmux | `fix: AppleScript count windows + working directory` (our PR) | Open |
| (not filed) | cmux | Per-terminal PID/tty in AppleScript sdef | — |

Once Ghostty adds `pid`/`tty` to its AppleScript terminal class, we can match by PID instead of cwd, eliminating the same-cwd ambiguity entirely. The same fix could be requested for cmux (identical sdef structure).

### No Performance Impact
Same number of `lsof` calls as before. Only change is `find()` → `find() with claimedSessionIds exclusion`.

_🤖 On behalf of @grimmerk — generated with Claude Code_


