### PR TITLE
fix: VS Code sessions causing false active dots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.52
+
+- Fix: VS Code Claude Code sessions no longer cause false purple dots on terminal sessions
+
 ## 1.0.51
 
 - Fix: cache update status to survive renderer race condition

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "CodeV",
   "productName": "CodeV",
-  "version": "1.0.51",
+  "version": "1.0.52",
   "description": "Quick switcher for VS Code, Cursor, and Claude Code sessions",
   "repository": {
     "type": "git",

--- a/src/claude-session-utility.ts
+++ b/src/claude-session-utility.ts
@@ -576,7 +576,11 @@ export const detectActiveSessions = async (): Promise<Map<string, number>> => {
           const pid = data.pid as number;
           const sessionId = data.sessionId as string;
           const cwd = data.cwd as string;
+          const entrypoint = data.entrypoint as string;
           if (!pid || !sessionId) continue;
+
+          // Skip non-terminal sessions (VS Code, Claude Desktop) — can't switch to them
+          if (entrypoint && entrypoint !== 'cli') continue;
 
           // Verify process is still alive
           try { process.kill(pid, 0); } catch { continue; }


### PR DESCRIPTION
## Summary

VS Code Claude Code sessions (`entrypoint: "claude-vscode"`) were causing false purple active dots on unrelated terminal sessions.

## Root cause

Detection flow in `detectActiveSessions()` (PR #67):

1. Read `~/.claude/sessions/<PID>.json` → PID alive ✓ (VS Code is running)
2. Match `sessionId` against `history.jsonl` → **no match** (VS Code sessions are [not written to history.jsonl](https://github.com/anthropics/claude-code/issues/24579))
3. Fall to cwd fallback → find a **closed** terminal session with the same cwd in history.jsonl
4. `cwdCandidates.length === 1` → mark that closed session as active → **wrong purple dot**

The user observed:
- `codex-ff` project showed purple dot, but no terminal had that session open
- The actual active session was VS Code's Claude Code extension (different content)
- Clicking the session couldn't switch to it
- Closing VS Code made the dot disappear

## Fix

Skip non-CLI sessions at step 1:

```typescript
const entrypoint = data.entrypoint as string;
// Skip non-terminal sessions (VS Code, Claude Desktop) — can't switch to them
if (entrypoint && entrypoint !== 'cli') continue;
```

Known `entrypoint` values (from `~/.claude/sessions/<PID>.json`):

| `entrypoint` | Source | Action |
|---|---|---|
| `cli` | Terminal (iTerm2, Ghostty, cmux) | ✓ Proceed with detection |
| `claude-vscode` | VS Code extension | Skip |
| `claude-desktop` | Claude Desktop app | Skip |
| `undefined` | Old Claude Code PID files | ✓ Proceed (backward compat) |

## No side effects

- **Legacy fallback** (sessions/ dir doesn't exist): unaffected — it uses `ps aux`, not sessions/ files
- **Cross-ref disambiguation**: unaffected — non-cli PIDs never enter `needsCrossRef`
- **Future VS Code support** (issue #66 item #5): this is the correct foundation — when we add `[VSCODE]` badge and VS Code window activation, we'll handle non-cli entrypoints in a separate code path instead of letting them fall into the terminal detection flow

## Test plan

- [x] VS Code with active Claude Code session in codex-ff → no purple dot on terminal sessions
- [x] Close VS Code → no change (dot was already absent)
- [ ] Terminal sessions still show purple dots correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_🤖 On behalf of @grimmerk — generated with Claude Code_

