### PR TITLE
fix: cmux launch waits for ready when not running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.54
+
+- Fix: cmux launch now waits for cmux to be ready before creating workspace (#75)
+- Fix: revert accidental DevTools enable in switcher window
+
 ## 1.0.53
 
 - Upgrade Electron 29 → 41 (Node 24, Chromium 146)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "CodeV",
   "productName": "CodeV",
-  "version": "1.0.53",
+  "version": "1.0.54",
   "description": "Quick switcher for VS Code, Cursor, and Claude Code sessions",
   "repository": {
     "type": "git",

--- a/src/claude-session-utility.ts
+++ b/src/claude-session-utility.ts
@@ -1163,26 +1163,57 @@ export const openSessionInCmux = (
     })();
   } else {
     // Launch new workspace with command
-    const cmuxCmd = `${CMUX_CLI} new-workspace --cwd "${projectPath}" --command "claude --resume ${sessionId}"`;
-    console.log('[cmux] launch cmd:', cmuxCmd);
-    exec(cmuxCmd,
-      { encoding: 'utf-8', timeout: 5000 },
-      (error: any, stdout: string, stderr: string) => {
-        console.log('[cmux] launch result:', { error: error?.message, stdout, stderr });
-        if (error) {
-          console.error('cmux new-workspace failed, falling back to clipboard:', error.message);
-          copyResumeCommand(sessionId, projectPath);
-          exec('osascript -e \'tell application "cmux" to activate\'');
-        } else {
-          // Select the newly created workspace and activate cmux
-          const wsMatch = stdout.match(/workspace:\d+/);
-          if (wsMatch) {
-            exec(`${CMUX_CLI} select-workspace --workspace ${wsMatch[0]}`);
+    // cmux's new-workspace doesn't auto-launch cmux (unlike open-cwd),
+    // so we need to check if cmux is running and launch it first if needed.
+    const launchInCmux = () => {
+      const cmuxCmd = `${CMUX_CLI} new-workspace --cwd "${projectPath}" --command "claude --resume ${sessionId}"`;
+      console.log('[cmux] launch cmd:', cmuxCmd);
+      exec(cmuxCmd,
+        { encoding: 'utf-8', timeout: 5000 },
+        (error: any, stdout: string, stderr: string) => {
+          console.log('[cmux] launch result:', { error: error?.message, stdout, stderr });
+          if (error) {
+            console.error('cmux new-workspace failed, falling back to clipboard:', error.message);
+            copyResumeCommand(sessionId, projectPath);
+            exec('osascript -e \'tell application "cmux" to activate\'');
+          } else {
+            const wsMatch = stdout.match(/workspace:\d+/);
+            if (wsMatch) {
+              exec(`${CMUX_CLI} select-workspace --workspace ${wsMatch[0]}`);
+            }
+            exec('osascript -e \'tell application "cmux" to activate\'');
           }
-          exec('osascript -e \'tell application "cmux" to activate\'');
         }
+      );
+    };
+
+    // Check if cmux is running via pgrep
+    exec('pgrep -x cmux', (error: any) => {
+      if (error) {
+        // cmux not running — launch it and wait until ready
+        console.log('[cmux] not running, launching...');
+        exec('open -a cmux');
+        let attempts = 0;
+        const waitForCmux = () => {
+          attempts++;
+          exec(`${CMUX_CLI} tree 2>/dev/null`, { timeout: 2000 }, (err: any) => {
+            if (!err) {
+              console.log(`[cmux] ready after ${attempts * 500}ms`);
+              launchInCmux();
+            } else if (attempts < 10) {
+              setTimeout(waitForCmux, 500);
+            } else {
+              console.error('[cmux] timed out waiting for cmux, falling back to clipboard');
+              copyResumeCommand(sessionId, projectPath);
+              exec('osascript -e \'tell application "cmux" to activate\'');
+            }
+          });
+        };
+        setTimeout(waitForCmux, 500);
+      } else {
+        launchInCmux();
       }
-    );
+    });
   }
 };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -404,9 +404,9 @@ const createSwitcherWindow = (): BrowserWindow => {
   // and load the index.html of the app.
   window.loadURL(SWITCHER_WINDOW_WEBPACK_ENTRY);
 
-  if (isDebug) {
-    window.webContents.openDevTools({ mode: 'detach' });
-  }
+  // if (isDebug) {
+  //   window.webContents.openDevTools({ mode: 'detach' });
+  // }
 
   if (tray) {
     // TODO: change to use some Tray method & not set tray here


### PR DESCRIPTION
## Summary
- Fix: cmux session launch fails when cmux is not running (#75)
- Fix: revert accidental DevTools enable in switcher window (from PR #79)

## Root cause
cmux's `new-workspace` CLI command doesn't have `launchIfNeeded` logic (unlike `open-cwd`). When cmux isn't running, the command silently fails because it can't connect to the socket.

## Fix
Before calling `new-workspace`, check if cmux is running via `pgrep -x cmux`:
- **Running** → call `new-workspace` directly
- **Not running** → `open -a cmux` → retry `cmux tree` every 500ms until ready (max 5s) → then `new-workspace`
- **Timeout** → fallback to clipboard (existing behavior)

## Test plan
- [ ] Quit cmux → click session item with Launch Terminal = cmux → cmux opens + session resumes
- [ ] cmux already running → click session item → works as before (no extra delay)
- [ ] Switcher window no longer opens DevTools in dev mode

Fixes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_🤖 On behalf of @grimmerk — generated with Claude Code_
