### PR TITLE
fix: bump CI Node.js 20 → 22 for Electron 41

### DIFF
--- a/.github/workflows/notarize.yml
+++ b/.github/workflows/notarize.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'yarn'
 
       - name: Install dependencies


### PR DESCRIPTION
node-abi v4 requires Node >= 22.12.0. CI was using Node 20.

_🤖 On behalf of @grimmerk — generated with Claude Code_