### PR TITLE
fix: terminal cursor style + Cmd+K clear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.61
+
+- Fix: terminal cursor — white non-blinking block (matching iTerm2 style)
+- Feat: Cmd+K clears terminal screen
+- Feat: Shift+Enter sends newline in terminal (for Claude Code multi-line input)
+
 ## 1.0.60
 
 - Fix: terminal cd uses ~ shorthand + clear for cleaner output

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "CodeV",
   "productName": "CodeV",
-  "version": "1.0.60",
+  "version": "1.0.61",
   "description": "Quick switcher for VS Code, Cursor, and Claude Code sessions",
   "repository": {
     "type": "git",

--- a/src/terminal-tab.tsx
+++ b/src/terminal-tab.tsx
@@ -21,10 +21,10 @@ const TerminalTab = ({ visible }: { visible: boolean }) => {
       theme: {
         background: '#1e1e1e',
         foreground: '#e9e9e9',
-        cursor: '#00BCD4',
+        cursor: '#C0C0C0',
         selectionBackground: 'rgba(0, 188, 212, 0.3)',
       },
-      cursorBlink: true,
+      cursorBlink: false,
       allowProposedApi: true,
     });
 
@@ -39,6 +39,9 @@ const TerminalTab = ({ visible }: { visible: boolean }) => {
       // Cmd+←/→ → beginning/end of line
       if (e.type === 'keydown' && e.metaKey && e.key === 'ArrowLeft') { term.input('\x01'); return false; }
       if (e.type === 'keydown' && e.metaKey && e.key === 'ArrowRight') { term.input('\x05'); return false; }
+      if (e.type === 'keydown' && e.metaKey && e.key === 'k') { term.clear(); return false; }
+      // Shift+Enter → Ctrl+J (line feed) for Claude Code multi-line input
+      if (e.shiftKey && e.key === 'Enter') { if (e.type === 'keydown') term.input('\x0a'); return false; }
       return true;
     });
 


### PR DESCRIPTION
- White non-blinking block cursor (matching iTerm2 style)
- Cmd+K clears terminal screen

_🤖 On behalf of @grimmerk — generated with Claude Code_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cmd+K keyboard shortcut to clear the terminal screen.
  * Shift+Enter inserts a newline for multi-line terminal input.

* **Bug Fixes**
  * Terminal cursor now appears as a white, non-blinking block to match expected rendering.

* **Chores**
  * Package version bumped to 1.0.61.

* **Documentation**
  * Changelog updated with the 1.0.61 release notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->