### PR TITLE
fix: detect CodeV embedded terminal sessions correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.63
+
+- Fix: Terminal tab sessions correctly detected as CODEV (not parent terminal)
+- Click Terminal tab session → switches to Term tab instead of external terminal
+
 ## 1.0.62
 
 - Feat: session status hooks — colored dots for working (pulse) / idle / needs-attention (blink)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "CodeV",
   "productName": "CodeV",
-  "version": "1.0.62",
+  "version": "1.0.63",
   "description": "Quick switcher for VS Code, Cursor, and Claude Code sessions",
   "repository": {
     "type": "git",

--- a/src/claude-session-utility.ts
+++ b/src/claude-session-utility.ts
@@ -186,7 +186,12 @@ export const detectTerminalApp = async (pid: number): Promise<string> => {
 
     const commLower = comm.toLowerCase();
     // CodeV's embedded terminal (node-pty runs under Electron)
-    if (commLower.includes('electron') || commLower.includes('codev')) return 'codev';
+    if (commLower.includes('codev')) return 'codev';
+    // Check if this Electron process is CodeV by inspecting command line
+    if (commLower.includes('electron')) {
+      const cmdline = (await execPromise(`ps -o command= -p ${currentPid} 2>/dev/null`)).trim();
+      if (cmdline.toLowerCase().includes('codev')) return 'codev';
+    }
     if (commLower.includes('iterm') || commLower.includes('iterm2')) return 'iterm2';
     if (commLower.includes('cmux')) return 'cmux';
     if (commLower.includes('ghostty')) return 'ghostty';

--- a/src/main.ts
+++ b/src/main.ts
@@ -1062,8 +1062,11 @@ const trayToggleEvtHandler = async () => {
 
   // Set callback for CodeV embedded terminal sessions
   setCodevTerminalCallback((_sessionId: string) => {
-    switcherWindow?.webContents.send('switch-to-terminal');
     showSwitcherWindow();
+    // Send after show to ensure window exists and is ready
+    setTimeout(() => {
+      switcherWindow?.webContents.send('switch-to-terminal');
+    }, 50);
   });
 
   // Pre-initialize aiAssistantWindow for faster first open


### PR DESCRIPTION
## Problem

Sessions opened in CodeV's Terminal tab are misdetected as Ghostty (or whatever terminal launched `yarn start`). Process tree walks up: `claude → node-pty → Electron → Ghostty`.

Clicking the session item switches to the wrong Ghostty tab instead of CodeV's Term tab.

## Fix

- Add `'codev'` terminal type — detected when process tree hits `Electron` or `CodeV` before any external terminal
- `openSessionInCodeV()` sends `switch-to-terminal` IPC to renderer → switches to Term tab
- Badge shows `CODEV` instead of `GHOSTTY`
- Excluded from cross-ref cwd fallback

## Test plan
- [ ] Open Claude Code in Terminal tab → session shows CODEV badge
- [ ] Click that session item → switches to Term tab (not Ghostty)
- [ ] Sessions in external terminals still detected correctly

_🤖 On behalf of @grimmerk — generated with Claude Code_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects CodeV’s embedded terminal and routes session clicks to the Term tab inside CodeV. Prevents sessions being labeled as Ghostty and opening the wrong app.

- **Bug Fixes**
  - Added `codev` terminal type when the process tree hits Electron/CodeV before any external terminal, checking Electron cmdline for `CodeV`.
  - For `codev` sessions, show the switcher window first, then send `switch-to-terminal` IPC (with a short delay) to focus the Term tab.
  - Show CODEV badge for embedded terminal sessions.
  - Excluded `codev` from cwd fallback cross-ref to avoid misattribution.

<sup>Written for commit 68e85cc40259d1731c18d021d848ee2d0f514ad0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added integration to open and manage sessions inside CodeV embedded terminals.
* **Bug Fixes**
  * Improved detection so CodeV terminal tabs are correctly identified and not attributed to parent terminals.
  * Clicking a CodeV terminal tab now switches to the in-app Term view instead of launching an external terminal.
* **Chores**
  * Changelog updated and version bumped to 1.0.63.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->