### PR TITLE
style: remove quotes around custom session titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.65
+
+- Style: remove quotes around custom session titles (color already distinguishes them)
+
 ## 1.0.64
 
 - Feat: show last assistant response for all sessions (not just active)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "CodeV",
   "productName": "CodeV",
-  "version": "1.0.64",
+  "version": "1.0.65",
   "description": "Quick switcher for VS Code, Cursor, and Claude Code sessions",
   "repository": {
     "type": "git",

--- a/src/switcher-ui.tsx
+++ b/src/switcher-ui.tsx
@@ -1002,7 +1002,7 @@ function SwitcherApp() {
                         </span>
                         {customTitles[session.sessionId] && (
                           <span style={{ color: '#7ec87e', fontSize: '13px', fontWeight: '500' }}>
-                            {' '}· "<Highlighter
+                            {' '}· <Highlighter
                               searchWords={sessionSearchValue.split(/\s+/).filter(Boolean)}
                               textToHighlight={customTitles[session.sessionId].slice(0, 35)}
                               highlightStyle={{
@@ -1011,7 +1011,7 @@ function SwitcherApp() {
                                 padding: '0 2px',
                                 borderRadius: '2px',
                               }}
-                            />"
+                            />
                           </span>
                         )}
                         {branches[session.sessionId] && (


### PR DESCRIPTION
Remove `""` quotes from custom session titles — green color already distinguishes them from project name.

Before: `codev · "codev session state hook"`
After: `codev · codev session state hook`

_🤖 On behalf of @grimmerk — generated with Claude Code_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove quotes around custom session titles in the switcher to reduce clutter; the green color already distinguishes them from project names. Also bumps version to 1.0.65 and updates the changelog.

<sup>Written for commit f6a853e1902be02a6f66c7fbac29da0ac3550e8c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Custom session titles no longer display with quotation marks; color differentiation is now used to distinguish them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->