### PR TITLE
feat: Normal App mode, Settings UI tabs, Dev Hub sub-title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 1.0.70
+
+- Feat: Normal App mode — window stays visible, shows in Dock, draggable
+  - Toggle in Settings: Normal App (default for new users) / Menu Bar
+  - Instant switching, no restart needed
+  - `Cmd+Ctrl+R` toggles show/hide in both modes
+  - Title bar shows "Dev Hub" sub-title + mode indicator + shortcut key
+  - Banner on first launch and mode switch (auto-dismiss)
+  - Clicking Dock icon shows hidden window
+- Feat: Settings UI redesigned with tabs (General / Sessions / Shortcuts)
+  - All settings visible without scrolling
+  - No more content changing based on active main tab
+  - Hints on context-specific settings (projects/sessions/tray)
+- Style: Terminal renamed to Terminal.app in Launch Terminal dropdown
+- Style: title bar padding reduced for tighter layout
+
 ## 1.0.69
 
 - Feat: adaptive VS Code resume via IDE lock file polling

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Quick switcher for VS Code/Cursor projects, Claude Code session manager with liv
 
 ### Quick Switcher for VS Code / Cursor Projects
 
-Spotlight-like quick open: press `⌃+⌘+R` or click the menu bar icon to launch the Quick Switcher. Search and select a project to open or switch to it in VS Code or Cursor — even if the IDE is not running yet.
+Press `⌃+⌘+R` or click the menu bar icon to launch the Quick Switcher. Search and select a project to open or switch to it in VS Code or Cursor — even if the IDE is not running yet. In Normal App mode, the window stays visible for monitoring; in Menu Bar mode, it works like Spotlight.
 
 - **Recent projects** (white items): your latest VS Code/Cursor folders, workspaces, and recently opened files — read directly from IDE data, no extension required
 - **Working folder items** (green items): first-level subfolders found by scanning a folder you choose (Settings → Working Directory)
@@ -51,6 +51,22 @@ CodeV includes a built-in terminal tab (powered by xterm.js + node-pty, same tec
 - `⌘+K` clears screen, `Shift+Enter` for multi-line input (Claude Code compatible)
 - `Cmd+←/→` jumps to beginning/end of line
 - **"Claude in Terminal" button**: launches a new Claude Code session in the configured external terminal using the current working directory
+
+### App Mode
+
+CodeV supports two window modes, configurable in Settings → App Mode:
+
+| | Normal App (default) | Menu Bar |
+|--|--|--|
+| **Dock** | Visible | Hidden |
+| **On blur** | Stays visible | Auto-hides |
+| **Window position** | Remembers last position, draggable | Centers on screen each time |
+| **On startup** | Shows window | Hidden until shortcut/tray click |
+| **`⌃+⌘+R`** | Toggle show/hide | Toggle show/hide |
+| **Click Dock icon** | Shows hidden window | N/A |
+| **Best for** | Dashboard / monitoring (keep in corner) | Quick access (spotlight-like) |
+
+**Real-time updates when unfocused (Normal mode):** Status dots, final assistant/user messages, and session order update via fs.watch — no need to re-focus. New sessions and full list refresh only occur on re-focus.
 
 ### Tab Switching
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Quick switcher for VS Code/Cursor projects, Claude Code session manager with liv
 Press `⌃+⌘+R` or click the menu bar icon to launch the Quick Switcher. Search and select a project to open or switch to it in VS Code or Cursor — even if the IDE is not running yet. In Normal App mode, the window stays visible for monitoring; in Menu Bar mode, it works like Spotlight.
 
 - **Recent projects** (white items): your latest VS Code/Cursor folders, workspaces, and recently opened files — read directly from IDE data, no extension required
-- **Working folder items** (green items): first-level subfolders found by scanning a folder you choose (Settings → Working Directory)
+- **Working folder items** (green items): first-level subfolders found by scanning a folder you choose (Settings → General → Working Dir)
 - **Git branch display**: shows the current branch for each recently opened project
 - Multi-word search across project names, paths, and branch names
-- Supports VS Code and Cursor — switch between them in Settings → IDE Preference
+- Supports VS Code and Cursor — switch between them in Settings → General → IDE
 - Remove items from the recent list by hovering and clicking "x"
 - **Quick-launch Claude session**: `⌘+Enter` to launch a new Claude Code session in the configured terminal, `⇧+Enter` to launch in CodeV's embedded terminal, `⌘+Click` as mouse alternative
 
@@ -46,7 +46,7 @@ For the full same-cwd accuracy matrix (detection + switch by launch method and t
 CodeV includes a built-in terminal tab (powered by xterm.js + node-pty, same technology as VS Code's integrated terminal). Press `⌃+⌘+T` from anywhere (global shortcut) or `⌘+3` when CodeV is in foreground to open it.
 
 - Pre-spawned on app start for instant access
-- Default working directory: Settings → Working Directory (fallback to home)
+- Default working directory: Settings → General → Working Dir (fallback to home)
 - Terminal state preserved when switching tabs
 - `⌘+K` clears screen, `Shift+Enter` for multi-line input (Claude Code compatible)
 - `Cmd+←/→` jumps to beginning/end of line
@@ -54,7 +54,7 @@ CodeV includes a built-in terminal tab (powered by xterm.js + node-pty, same tec
 
 ### App Mode
 
-CodeV supports two window modes, configurable in Settings → App Mode:
+CodeV supports two window modes, configurable in Settings → General → App Mode:
 
 | | Normal App (default) | Menu Bar |
 |--|--|--|

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "CodeV",
   "productName": "CodeV",
-  "version": "1.0.69",
+  "version": "1.0.70",
   "description": "Quick switcher for VS Code, Cursor, and Claude Code sessions",
   "repository": {
     "type": "git",

--- a/src/electron-api.d.ts
+++ b/src/electron-api.d.ts
@@ -28,6 +28,10 @@ interface IElectronAPI {
   getUpdateStatus: () => Promise<{ status: string; releaseName?: string; error?: string } | null>;
   onUpdateStatus: (callback: IpcCallback) => void;
 
+  // App mode
+  getAppMode: () => Promise<string>;
+  setAppMode: (mode: string) => void;
+
   // Session terminal settings
   getSessionTerminalApp: () => Promise<string>;
   setSessionTerminalApp: (app: string) => void;

--- a/src/electron-api.d.ts
+++ b/src/electron-api.d.ts
@@ -32,6 +32,7 @@ interface IElectronAPI {
   getAppMode: () => Promise<string>;
   setAppMode: (mode: string) => void;
   onAppModeChanged: (callback: IpcCallback) => void;
+  onShortcutsUpdated: (callback: IpcCallback) => void;
 
   // Session terminal settings
   getSessionTerminalApp: () => Promise<string>;

--- a/src/electron-api.d.ts
+++ b/src/electron-api.d.ts
@@ -31,6 +31,7 @@ interface IElectronAPI {
   // App mode
   getAppMode: () => Promise<string>;
   setAppMode: (mode: string) => void;
+  onAppModeChanged: (callback: IpcCallback) => void;
 
   // Session terminal settings
   getSessionTerminalApp: () => Promise<string>;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1081,11 +1081,6 @@ const trayToggleEvtHandler = async () => {
   }
 
   switcherWindow = createSwitcherWindow();
-  // Normal mode: show window after bootstrap (server must be ready for API calls)
-  if (appMode === 'normal') {
-    // Delay show to ensure bootstrap() has completed (runs earlier in this block)
-    setTimeout(() => showSwitcherWindow(), 100);
-  }
   if (isDebug) {
     console.log('when ready');
   }
@@ -1279,6 +1274,11 @@ const trayToggleEvtHandler = async () => {
 
   // Load user settings
   await loadUserSettings();
+
+  // Normal mode: show window after bootstrap + settings loaded (server ready for API calls)
+  if (appMode === 'normal') {
+    showSwitcherWindow();
+  }
 
   let title = '';
   if (!isDebug) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1081,9 +1081,10 @@ const trayToggleEvtHandler = async () => {
   }
 
   switcherWindow = createSwitcherWindow();
-  // Normal mode: show window immediately on startup
+  // Normal mode: show window after bootstrap (server must be ready for API calls)
   if (appMode === 'normal') {
-    showSwitcherWindow();
+    // Delay show to ensure bootstrap() has completed (runs earlier in this block)
+    setTimeout(() => showSwitcherWindow(), 100);
   }
   if (isDebug) {
     console.log('when ready');
@@ -1973,7 +1974,7 @@ ipcMain.on('set-app-mode', async (_event, mode: string) => {
   if (newMode === 'menubar') {
     app.dock.hide();
   } else {
-    app.dock.show();
+    await app.dock.show();
   }
   // Notify renderer to update drag region
   const window = getSwitcherWindow();

--- a/src/main.ts
+++ b/src/main.ts
@@ -110,8 +110,6 @@ const showSwitcherWindow = () => {
     const position = getWindowPosition();
     window.setPosition(position.x, position.y, false);
   }
-  // Send app mode to renderer so it can enable/disable drag region
-  window.webContents.send('app-mode-changed', appMode);
   if (window.isMinimized()) {
     window.restore();
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1703,6 +1703,8 @@ const trayToggleEvtHandler = async () => {
     if (registered) {
       await settings.set(`shortcut-${key}`, accelerator);
       await syncTrayShortcuts();
+      // Notify switcher window to update shortcut display
+      switcherWindow?.webContents.send('shortcuts-updated', await getCurrentShortcuts());
       return { success: true };
     } else {
       // Re-register the old shortcut since the new one failed
@@ -1718,6 +1720,8 @@ const trayToggleEvtHandler = async () => {
     }
     await registerAllShortcuts();
     await syncTrayShortcuts();
+    // Notify switcher window to update shortcut display
+    switcherWindow?.webContents.send('shortcuts-updated', DEFAULT_SHORTCUTS);
     return DEFAULT_SHORTCUTS;
   });
 })();

--- a/src/main.ts
+++ b/src/main.ts
@@ -517,6 +517,11 @@ app.on('activate', () => {
   if (BrowserWindow.getAllWindows().length === 0) {
     switcherWindow = createSwitcherWindow();
   }
+  // Normal mode: clicking Dock icon shows hidden window
+  const window = getSwitcherWindow();
+  if (window && !window.isVisible()) {
+    showSwitcherWindow();
+  }
 });
 
 /** https://www.electronjs.org/docs/latest/tutorial/ipc */

--- a/src/main.ts
+++ b/src/main.ts
@@ -262,11 +262,7 @@ const getSwitcherWindow = () => {
 const hideSwitcherWindow = () => {
   const window = getSwitcherWindow();
   if (window) {
-    if (appMode === 'normal') {
-      window.minimize();
-    } else {
-      window.hide();
-    }
+    window.hide();
   }
 };
 
@@ -1318,8 +1314,7 @@ const trayToggleEvtHandler = async () => {
     } else {
       const window = getSwitcherWindow();
       
-      if (appMode === 'menubar' && window && window.isVisible() && !window.isMinimized()) {
-        // Menu bar mode: toggle hide
+      if (window && window.isVisible() && !window.isMinimized()) {
         if (isDebug) {
           console.log('Switcher window visible, hiding it');
         }
@@ -1977,6 +1972,11 @@ ipcMain.on('set-app-mode', async (_event, mode: string) => {
   const window = getSwitcherWindow();
   if (window) {
     window.webContents.send('app-mode-changed', newMode);
+    // Re-center when switching to menu bar mode
+    if (newMode === 'menubar') {
+      const position = getWindowPosition();
+      window.setPosition(position.x, position.y, false);
+    }
   }
 });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -105,11 +105,13 @@ const showSwitcherWindow = () => {
     window = switcherWindow;
   }
 
-  // Menu bar mode: always center on screen. Normal mode: keep last position.
   if (appMode === 'menubar') {
+    // Menu bar mode: always center on screen
     const position = getWindowPosition();
     window.setPosition(position.x, position.y, false);
   }
+  // Send app mode to renderer so it can enable/disable drag region
+  window.webContents.send('app-mode-changed', appMode);
   if (window.isMinimized()) {
     window.restore();
   }
@@ -1080,6 +1082,10 @@ const trayToggleEvtHandler = async () => {
   }
 
   switcherWindow = createSwitcherWindow();
+  // Normal mode: show window immediately on startup
+  if (appMode === 'normal') {
+    showSwitcherWindow();
+  }
   if (isDebug) {
     console.log('when ready');
   }
@@ -1312,7 +1318,8 @@ const trayToggleEvtHandler = async () => {
     } else {
       const window = getSwitcherWindow();
       
-      if (window && window.isVisible() && !window.isMinimized()) {
+      if (appMode === 'menubar' && window && window.isVisible() && !window.isMinimized()) {
+        // Menu bar mode: toggle hide
         if (isDebug) {
           console.log('Switcher window visible, hiding it');
         }
@@ -1965,6 +1972,11 @@ ipcMain.on('set-app-mode', async (_event, mode: string) => {
     app.dock.hide();
   } else {
     app.dock.show();
+  }
+  // Notify renderer to update drag region
+  const window = getSwitcherWindow();
+  if (window) {
+    window.webContents.send('app-mode-changed', newMode);
   }
 });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -81,6 +81,9 @@ let serverProcess: any;
 const WIN_WIDTH = 800;
 const WIN_HEIGHT = 600;
 
+// App mode: 'normal' (dock visible, no auto-hide) or 'menubar' (hidden dock, auto-hide on blur)
+let appMode: 'normal' | 'menubar' = 'normal'; // default to normal for new users
+
 const getWindowPosition = () => {
   const primaryDisplay = screen.getPrimaryDisplay();
   const { width, height } = primaryDisplay.workAreaSize;
@@ -95,19 +98,23 @@ const getWindowPosition = () => {
 // NOTE: setVisibleOnAllWorkspaces is needed ?
 const showSwitcherWindow = () => {
   let window = getSwitcherWindow();
-  
+
   if (!window) {
     // Recreate window if it has been destroyed
     switcherWindow = createSwitcherWindow();
     window = switcherWindow;
   }
-  
-  const position = getWindowPosition();
-  window.setPosition(position.x, position.y, false);
+
+  // Menu bar mode: always center on screen. Normal mode: keep last position.
+  if (appMode === 'menubar') {
+    const position = getWindowPosition();
+    window.setPosition(position.x, position.y, false);
+  }
+  if (window.isMinimized()) {
+    window.restore();
+  }
   window.show();
-  // mainWindow.setVisibleOnAllWorkspaces(true);
   window.focus();
-  // mainWindow.setVisibleOnAllWorkspaces(false);
 };
 
 const showAIAssistantWindow = () => {
@@ -253,11 +260,17 @@ const getSwitcherWindow = () => {
 const hideSwitcherWindow = () => {
   const window = getSwitcherWindow();
   if (window) {
-    window.hide();
+    if (appMode === 'normal') {
+      window.minimize();
+    } else {
+      window.hide();
+    }
   }
 };
 
 const onBlur = (event: any) => {
+  // Normal mode: don't auto-hide on blur
+  if (appMode === 'normal') return;
   hideSwitcherWindow();
 };
 
@@ -1016,6 +1029,12 @@ const trayToggleEvtHandler = async () => {
 (async () => {
   await app.whenReady();
 
+  // Load app mode setting early (before window creation)
+  appMode = ((await settings.get('app-mode')) as 'normal' | 'menubar') || 'normal';
+  if (appMode === 'menubar') {
+    app.dock.hide();
+  }
+
   // Auto-update: check for updates via update.electronjs.org (non-MAS only)
   if (!isMAS()) {
     try {
@@ -1293,7 +1312,7 @@ const trayToggleEvtHandler = async () => {
     } else {
       const window = getSwitcherWindow();
       
-      if (window && window.isVisible()) {
+      if (window && window.isVisible() && !window.isMinimized()) {
         if (isDebug) {
           console.log('Switcher window visible, hiding it');
         }
@@ -1934,6 +1953,21 @@ ipcMain.handle('get-session-statuses', async () => {
   return obj;
 });
 
+ipcMain.handle('get-app-mode', async () => {
+  return appMode;
+});
+
+ipcMain.on('set-app-mode', async (_event, mode: string) => {
+  const newMode = mode === 'menubar' ? 'menubar' : 'normal';
+  await settings.set('app-mode', newMode);
+  appMode = newMode;
+  if (newMode === 'menubar') {
+    app.dock.hide();
+  } else {
+    app.dock.show();
+  }
+});
+
 ipcMain.handle('get-session-terminal-app', async () => {
   return (await settings.get('session-terminal-app')) || 'iterm2';
 });
@@ -2077,4 +2111,4 @@ ipcMain.handle('detect-active-ide-projects', async () => {
   return Array.from(folderNames);
 });
 
-app.dock.hide();
+// app.dock.hide() moved to async init block (after settings loaded)

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -65,6 +65,7 @@ const PopupDefaultExample = ({
   const [isMASBuild, setIsMASBuild] = useState(false);
   const [sessionStatusHooks, setSessionStatusHooks] = useState(true);
   const [appModeState, setAppModeState] = useState('normal');
+  const [settingsTab, setSettingsTab] = useState<'general' | 'sessions' | 'shortcuts'>('general');
   const [ideDataAccessGranted, setIdeDataAccessGranted] = useState(false);
   const [shortcuts, setShortcuts] = useState({
     quickSwitcher: 'Command+Control+R',
@@ -321,11 +322,33 @@ const PopupDefaultExample = ({
             </span>
           </div>
 
-          {/* General settings (always visible) */}
-          <div style={{ padding: '4px 0', borderBottom: '1px solid #333' }}>
-            <div style={{ ...rowStyle, padding: '4px 16px' }}>
-              <span style={{ ...labelStyle, fontSize: '11px', color: '#888', textTransform: 'uppercase' as const, letterSpacing: '0.5px' }}>General</span>
-            </div>
+          {/* Settings tabs */}
+          <div style={{ display: 'flex', borderBottom: '1px solid #333', padding: '0 16px' }}>
+            {(['general', 'sessions', 'shortcuts'] as const).map((tab) => (
+              <button
+                key={tab}
+                onClick={() => setSettingsTab(tab)}
+                style={{
+                  padding: '6px 12px',
+                  fontSize: '12px',
+                  border: 'none',
+                  outline: 'none',
+                  cursor: 'pointer',
+                  backgroundColor: 'transparent',
+                  color: settingsTab === tab ? THEME.primary : '#888',
+                  borderBottom: settingsTab === tab ? `2px solid ${THEME.primary}` : '2px solid transparent',
+                  transition: 'color 0.2s',
+                  textTransform: 'capitalize' as const,
+                }}
+              >
+                {tab}
+              </button>
+            ))}
+          </div>
+
+          {/* General tab */}
+          {settingsTab === 'general' && (
+          <div style={{ padding: '4px 0' }}>
             <div style={rowStyle}>
               <span style={labelStyle}>Default Tab</span>
               <select
@@ -466,175 +489,140 @@ const PopupDefaultExample = ({
                 </select>
               </div>
             )}
-          </div>
-
-          {/* Projects settings (only in Projects tab) */}
-          {switcherMode === 'projects' && (
-            <div style={{ padding: '4px 0', borderBottom: '1px solid #333' }}>
-              <div style={{ ...rowStyle, padding: '4px 16px' }}>
-                <span style={{ ...labelStyle, fontSize: '11px', color: '#888', textTransform: 'uppercase' as const, letterSpacing: '0.5px' }}>Projects</span>
-              </div>
-              <div style={{ ...rowStyle, gap: '6px' }}>
-                <span style={labelStyle}>IDE</span>
-                <select
-                  value={idePreference}
-                  onChange={(e) => {
-                    const ide = e.target.value;
-                    setIdePreference(ide);
-                    window.electronAPI.notifyIDEPreferenceChanged(ide);
-                    if (isMASBuild) {
-                      window.electronAPI.checkIDEDataAccess(ide).then((granted: boolean) => {
-                        setIdeDataAccessGranted(granted);
-                      });
-                    }
-                  }}
-                  style={selectStyle}
-                >
-                  <option value="VSCode">VS Code</option>
-                  <option value="Cursor">Cursor</option>
-                </select>
-                {isMASBuild && (
-                  <button
-                    onClick={() => window.electronAPI.openIDEDataSelector(idePreference)}
-                    style={{
-                      backgroundColor: ideDataAccessGranted ? '#28a745' : THEME.primary,
-                      color: 'white',
-                      border: 'none',
-                      borderRadius: '3px',
-                      padding: '3px 6px',
-                      fontSize: '10px',
-                      cursor: 'pointer',
-                      flexShrink: 0,
-                    }}
-                  >
-                    {ideDataAccessGranted ? '✓' : 'Grant'}
-                  </button>
-                )}
-              </div>
-              <div style={{ padding: '4px 16px 2px' }}>
-                <span style={{ fontSize: '11px', color: '#666' }}>Claude Session Launch</span>
-                {[
-                  { keys: '\u2318+Enter', label: 'New Claude Session' },
-                  { keys: '\u21E7+Enter', label: 'New Claude (CodeV Term)' },
-                  { keys: '\u2318+Click', label: 'New Claude Session' },
-                ].map((row) => (
-                  <div key={row.keys} style={{ display: 'flex', justifyContent: 'space-between', padding: '1px 0' }}>
-                    <span style={{ fontSize: '11px', color: '#888', fontFamily: 'monospace' }}>{row.keys}</span>
-                    <span style={{ fontSize: '11px', color: '#888' }}>{row.label}</span>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* Sessions settings (only in Sessions tab) */}
-          {switcherMode === 'sessions' && (
-            <div style={{ padding: '4px 0', borderBottom: '1px solid #333' }}>
-              <div style={{ ...rowStyle, padding: '4px 16px' }}>
-                <span style={{ ...labelStyle, fontSize: '11px', color: '#888', textTransform: 'uppercase' as const, letterSpacing: '0.5px' }}>Sessions</span>
-              </div>
-              <div style={rowStyle}>
-                <span style={labelStyle} title="User prompt display mode. Assistant response (◀ blue text) always shown.">Session Preview</span>
-                <select
-                  value={sessionDisplayMode}
-                  onChange={(e) => {
-                    const val = e.target.value;
-                    setSessionDisplayMode(val);
-                    window.electronAPI.setSessionDisplayMode(val);
-                    if (saveCallback) saveCallback('sessionDisplayMode', val);
-                  }}
-                  style={selectStyle}
-                >
-                  <option value="first">First User Prompt</option>
-                  <option value="last">Last User Prompt</option>
-                  <option value="both">First + Last</option>
-                </select>
-              </div>
-              <div style={{ padding: '0 16px 2px', fontSize: '9px', color: '#555' }}>
-                ◀ Assistant response always shown
-              </div>
-              <div style={rowStyle}>
-                <span style={labelStyle} title="Uses Claude Code hooks to detect session state">Session Status <span style={{ fontSize: '10px', color: '#888' }}>(hooks)</span></span>
-                <label
+            <div style={{ ...rowStyle, gap: '6px' }}>
+              <span style={labelStyle}>IDE</span>
+              <select
+                value={idePreference}
+                onChange={(e) => {
+                  const ide = e.target.value;
+                  setIdePreference(ide);
+                  window.electronAPI.notifyIDEPreferenceChanged(ide);
+                  if (isMASBuild) {
+                    window.electronAPI.checkIDEDataAccess(ide).then((granted: boolean) => {
+                      setIdeDataAccessGranted(granted);
+                    });
+                  }
+                }}
+                style={selectStyle}
+              >
+                <option value="VSCode">VS Code</option>
+                <option value="Cursor">Cursor</option>
+              </select>
+              {isMASBuild && (
+                <button
+                  onClick={() => window.electronAPI.openIDEDataSelector(idePreference)}
                   style={{
-                    position: 'relative',
-                    display: 'inline-block',
-                    width: '40px',
-                    height: '22px',
+                    backgroundColor: ideDataAccessGranted ? '#28a745' : THEME.primary,
+                    color: 'white',
+                    border: 'none',
+                    borderRadius: '3px',
+                    padding: '3px 6px',
+                    fontSize: '10px',
                     cursor: 'pointer',
+                    flexShrink: 0,
                   }}
                 >
-                  <input
-                    type="checkbox"
-                    checked={sessionStatusHooks}
-                    onChange={(e) => {
-                      const enabled = e.target.checked;
-                      setSessionStatusHooks(enabled);
-                      window.electronAPI.setSessionStatusHooksEnabled(enabled);
-                    }}
-                    style={{ opacity: 0, width: 0, height: 0 }}
-                  />
-                  <span
-                    style={{
-                      position: 'absolute',
-                      top: 0,
-                      left: 0,
-                      right: 0,
-                      bottom: 0,
-                      backgroundColor: sessionStatusHooks ? THEME.primary : '#555',
-                      borderRadius: '11px',
-                      transition: 'background-color 0.2s',
-                    }}
-                  />
-                  <span
-                    style={{
-                      position: 'absolute',
-                      top: '2px',
-                      left: sessionStatusHooks ? '20px' : '2px',
-                      width: '18px',
-                      height: '18px',
-                      backgroundColor: '#fff',
-                      borderRadius: '50%',
-                      transition: 'left 0.2s',
-                    }}
-                  />
-                </label>
-              </div>
+                  {ideDataAccessGranted ? '✓' : 'Grant'}
+                </button>
+              )}
             </div>
+            <div style={{ ...rowStyle, gap: '8px' }}>
+              <span style={labelStyle}>Working Dir</span>
+              <div style={{ color: '#aaa', fontSize: '12px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1, textAlign: 'right' }}>
+                {workingFolderPath || 'None'}
+              </div>
+              <button
+                onClick={() => openFolderSelector()}
+                style={{ backgroundColor: 'transparent', border: '1px solid #555', borderRadius: '4px', padding: '2px 6px', cursor: 'pointer', fontSize: '12px', color: THEME.text.primary, flexShrink: 0 }}
+                title="Change Folder"
+              >
+                📁
+              </button>
+            </div>
+          </div>
           )}
 
-          {/* Shortcuts section */}
-          <div
-            style={{
-              borderTop: '1px solid #333',
-              padding: '10px 16px',
-            }}
-          >
-            <div
-              style={{
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItems: 'center',
-                marginBottom: '6px',
-              }}
-            >
-              <span
+          {/* Sessions tab */}
+          {settingsTab === 'sessions' && (
+          <div style={{ padding: '4px 0' }}>
+            <div style={rowStyle}>
+              <span style={labelStyle} title="User prompt display mode. Assistant response (◀ blue text) always shown.">Session Preview</span>
+              <select
+                value={sessionDisplayMode}
+                onChange={(e) => {
+                  const val = e.target.value;
+                  setSessionDisplayMode(val);
+                  window.electronAPI.setSessionDisplayMode(val);
+                  if (saveCallback) saveCallback('sessionDisplayMode', val);
+                }}
+                style={selectStyle}
+              >
+                <option value="first">First User Prompt</option>
+                <option value="last">Last User Prompt</option>
+                <option value="both">First + Last</option>
+              </select>
+            </div>
+            <div style={{ padding: '0 16px 2px', fontSize: '9px', color: '#555' }}>
+              ◀ Assistant response always shown
+            </div>
+            <div style={rowStyle}>
+              <span style={labelStyle} title="Uses Claude Code hooks to detect session state">Session Status <span style={{ fontSize: '10px', color: '#888' }}>(hooks)</span></span>
+              <label
                 style={{
-                  fontSize: '13px',
-                  fontWeight: 600,
-                  color: THEME.text.secondary,
+                  position: 'relative',
+                  display: 'inline-block',
+                  width: '40px',
+                  height: '22px',
+                  cursor: 'pointer',
                 }}
               >
-                Shortcuts
-              </span>
+                <input
+                  type="checkbox"
+                  checked={sessionStatusHooks}
+                  onChange={(e) => {
+                    const enabled = e.target.checked;
+                    setSessionStatusHooks(enabled);
+                    window.electronAPI.setSessionStatusHooksEnabled(enabled);
+                  }}
+                  style={{ opacity: 0, width: 0, height: 0 }}
+                />
+                <span
+                  style={{
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    right: 0,
+                    bottom: 0,
+                    backgroundColor: sessionStatusHooks ? THEME.primary : '#555',
+                    borderRadius: '11px',
+                    transition: 'background-color 0.2s',
+                  }}
+                />
+                <span
+                  style={{
+                    position: 'absolute',
+                    top: '2px',
+                    left: sessionStatusHooks ? '20px' : '2px',
+                    width: '18px',
+                    height: '18px',
+                    backgroundColor: '#fff',
+                    borderRadius: '50%',
+                    transition: 'left 0.2s',
+                  }}
+                />
+              </label>
+            </div>
+          </div>
+          )}
+
+          {/* Shortcuts tab */}
+          {settingsTab === 'shortcuts' && (
+          <div style={{ padding: '10px 16px' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '6px' }}>
+              <span style={{ fontSize: '13px', fontWeight: 600, color: THEME.text.secondary }}>Global Shortcuts</span>
               <span
                 onClick={handleResetShortcuts}
-                style={{
-                  fontSize: '11px',
-                  color: '#888',
-                  cursor: 'pointer',
-                  textDecoration: 'underline',
-                }}
+                style={{ fontSize: '11px', color: '#888', cursor: 'pointer', textDecoration: 'underline' }}
               >
                 Reset
               </span>
@@ -672,34 +660,18 @@ const PopupDefaultExample = ({
                     {shortcutError || 'Press keys...'}
                   </div>
                 ) : (
-                  <span
-                    style={{
-                      fontSize: '12px',
-                      color: THEME.text.secondary,
-                      fontFamily: 'monospace',
-                    }}
-                  >
+                  <span style={{ fontSize: '12px', color: THEME.text.secondary, fontFamily: 'monospace' }}>
                     {acceleratorToDisplay(shortcuts[row.key as keyof typeof shortcuts])}
                   </span>
                 )}
-                <span
-                  style={{
-                    fontSize: '12px',
-                    color: THEME.text.secondary,
-                    flex: 1,
-                  }}
-                >
-                  {row.label}
-                </span>
+                <span style={{ fontSize: '12px', color: THEME.text.secondary, flex: 1 }}>{row.label}</span>
                 <span
                   onClick={() => {
                     if (editingShortcut === row.key) {
-                      // Cancel editing — resume the shortcut
                       window.electronAPI.resumeShortcut(row.key);
                       setEditingShortcut(null);
                       setShortcutError('');
                     } else {
-                      // Start editing — pause the shortcut so it doesn't trigger
                       if (editingShortcut) {
                         window.electronAPI.resumeShortcut(editingShortcut);
                       }
@@ -708,17 +680,25 @@ const PopupDefaultExample = ({
                       setShortcutError('');
                     }
                   }}
-                  style={{
-                    fontSize: '11px',
-                    color: editingShortcut === row.key ? '#e05252' : THEME.primary,
-                    cursor: 'pointer',
-                    flexShrink: 0,
-                  }}
+                  style={{ fontSize: '11px', color: editingShortcut === row.key ? '#e05252' : THEME.primary, cursor: 'pointer', flexShrink: 0 }}
                 >
                   {editingShortcut === row.key ? 'Cancel' : 'Edit'}
                 </span>
               </div>
             ))}
+            <div style={{ borderTop: '1px solid #333', marginTop: '8px', paddingTop: '6px' }}>
+              <span style={{ fontSize: '11px', color: '#666' }}>Claude Session Launch</span>
+              {[
+                { keys: '\u2318+Enter', label: 'New Claude Session' },
+                { keys: '\u21E7+Enter', label: 'New Claude (CodeV Term)' },
+                { keys: '\u2318+Click', label: 'New Claude Session' },
+              ].map((row) => (
+                <div key={row.keys} style={{ display: 'flex', justifyContent: 'space-between', padding: '1px 0' }}>
+                  <span style={{ fontSize: '11px', color: '#888', fontFamily: 'monospace' }}>{row.keys}</span>
+                  <span style={{ fontSize: '11px', color: '#888' }}>{row.label}</span>
+                </div>
+              ))}
+            </div>
             <div style={{ borderTop: '1px solid #333', marginTop: '6px', paddingTop: '6px' }}>
               <span style={{ fontSize: '11px', color: '#666' }}>Tab Switching</span>
               {[
@@ -734,6 +714,7 @@ const PopupDefaultExample = ({
               ))}
             </div>
           </div>
+          )}
 
         </div>
       )}

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -472,7 +472,7 @@ const PopupDefaultExample = ({
             </div>
             {(sessionTerminalApp === 'iterm2' || sessionTerminalApp === 'terminal' || sessionTerminalApp === 'ghostty') && (
               <div style={rowStyle}>
-                <span style={labelStyle}>Launch Mode <span style={{ fontSize: '9px', color: '#666' }}>(tab/window)</span></span>
+                <span style={labelStyle}>Launch Mode</span>
                 <select
                   value={sessionTerminalMode}
                   onChange={(e) => {
@@ -523,19 +523,6 @@ const PopupDefaultExample = ({
                   {ideDataAccessGranted ? '✓' : 'Grant'}
                 </button>
               )}
-            </div>
-            <div style={{ ...rowStyle, gap: '8px' }}>
-              <span style={labelStyle}>Working Dir</span>
-              <div style={{ color: '#aaa', fontSize: '12px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1, textAlign: 'right' }}>
-                {workingFolderPath || 'None'}
-              </div>
-              <button
-                onClick={() => openFolderSelector()}
-                style={{ backgroundColor: 'transparent', border: '1px solid #555', borderRadius: '4px', padding: '2px 6px', cursor: 'pointer', fontSize: '12px', color: THEME.text.primary, flexShrink: 0 }}
-                title="Change Folder"
-              >
-                📁
-              </button>
             </div>
           </div>
           )}

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -472,7 +472,7 @@ const PopupDefaultExample = ({
             </div>
             {(sessionTerminalApp === 'iterm2' || sessionTerminalApp === 'terminal' || sessionTerminalApp === 'ghostty') && (
               <div style={rowStyle}>
-                <span style={{ ...labelStyle, paddingLeft: '16px', fontSize: '13px', color: '#aaa' }}>Open In</span>
+                <span style={{ ...labelStyle, paddingLeft: '12px', fontSize: '13px', color: '#aaa' }}>{'\u21B3'} Open In</span>
                 <select
                   value={sessionTerminalMode}
                   onChange={(e) => {

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -472,7 +472,7 @@ const PopupDefaultExample = ({
             </div>
             {(sessionTerminalApp === 'iterm2' || sessionTerminalApp === 'terminal' || sessionTerminalApp === 'ghostty') && (
               <div style={rowStyle}>
-                <span style={labelStyle}>Open In</span>
+                <span style={{ ...labelStyle, paddingLeft: '16px', fontSize: '13px', color: '#aaa' }}>Open In</span>
                 <select
                   value={sessionTerminalMode}
                   onChange={(e) => {

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -453,7 +453,7 @@ const PopupDefaultExample = ({
                 </button>
             </div>
             <div style={rowStyle}>
-              <span style={labelStyle}>Launch Terminal <span style={{ fontSize: '9px', color: '#666' }}>(sessions)</span></span>
+              <span style={labelStyle}>Launch Terminal</span>
               <select
                 value={sessionTerminalApp}
                 onChange={(e) => {
@@ -472,7 +472,7 @@ const PopupDefaultExample = ({
             </div>
             {(sessionTerminalApp === 'iterm2' || sessionTerminalApp === 'terminal' || sessionTerminalApp === 'ghostty') && (
               <div style={rowStyle}>
-                <span style={labelStyle}>Launch Mode</span>
+                <span style={labelStyle}>Open In <span style={{ fontSize: '9px', color: '#666' }}>(new tab/window)</span></span>
                 <select
                   value={sessionTerminalMode}
                   onChange={(e) => {

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -64,6 +64,7 @@ const PopupDefaultExample = ({
     useState('switcher_window');
   const [isMASBuild, setIsMASBuild] = useState(false);
   const [sessionStatusHooks, setSessionStatusHooks] = useState(true);
+  const [appModeState, setAppModeState] = useState('normal');
   const [ideDataAccessGranted, setIdeDataAccessGranted] = useState(false);
   const [shortcuts, setShortcuts] = useState({
     quickSwitcher: 'Command+Control+R',
@@ -80,6 +81,9 @@ const PopupDefaultExample = ({
   useEffect(() => {
     window.electronAPI.getAppVersion().then((version: string) => {
       setAppVersion(version);
+    });
+    window.electronAPI.getAppMode().then((mode: string) => {
+      setAppModeState(mode || 'normal');
     });
     window.electronAPI.getSessionTerminalApp().then((app: string) => {
       setSessionTerminalApp(app || 'iterm2');
@@ -336,6 +340,21 @@ const PopupDefaultExample = ({
                 <option value="projects">Projects</option>
                 <option value="sessions">Sessions</option>
                 <option value="terminal">Terminal</option>
+              </select>
+            </div>
+            <div style={rowStyle}>
+              <span style={labelStyle}>App Mode</span>
+              <select
+                value={appModeState}
+                onChange={(e) => {
+                  const mode = e.target.value;
+                  setAppModeState(mode);
+                  window.electronAPI.setAppMode(mode);
+                }}
+                style={selectStyle}
+              >
+                <option value="normal">Normal App</option>
+                <option value="menubar">Menu Bar</option>
               </select>
             </div>
             <div style={rowStyle}>

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -453,7 +453,7 @@ const PopupDefaultExample = ({
                 </button>
             </div>
             <div style={rowStyle}>
-              <span style={labelStyle}>Launch Terminal</span>
+              <span style={labelStyle}>Launch Terminal <span style={{ fontSize: '9px', color: '#666' }}>(projects/sessions)</span></span>
               <select
                 value={sessionTerminalApp}
                 onChange={(e) => {
@@ -472,7 +472,7 @@ const PopupDefaultExample = ({
             </div>
             {(sessionTerminalApp === 'iterm2' || sessionTerminalApp === 'terminal' || sessionTerminalApp === 'ghostty') && (
               <div style={rowStyle}>
-                <span style={labelStyle}>Open In <span style={{ fontSize: '9px', color: '#666' }}>(new tab/window)</span></span>
+                <span style={labelStyle}>Open In</span>
                 <select
                   value={sessionTerminalMode}
                   onChange={(e) => {

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -350,53 +350,6 @@ const PopupDefaultExample = ({
           {settingsTab === 'general' && (
           <div style={{ padding: '4px 0' }}>
             <div style={rowStyle}>
-              <span style={labelStyle}>Default Tab</span>
-              <select
-                value={defaultSwitcherMode}
-                onChange={(e) => {
-                  const mode = e.target.value;
-                  setDefaultSwitcherMode(mode);
-                  window.electronAPI.setDefaultSwitcherMode(mode);
-                }}
-                style={selectStyle}
-              >
-                <option value="projects">Projects</option>
-                <option value="sessions">Sessions</option>
-                <option value="terminal">Terminal</option>
-              </select>
-            </div>
-            <div style={rowStyle}>
-              <span style={labelStyle}>App Mode</span>
-              <select
-                value={appModeState}
-                onChange={(e) => {
-                  const mode = e.target.value;
-                  setAppModeState(mode);
-                  window.electronAPI.setAppMode(mode);
-                }}
-                style={selectStyle}
-              >
-                <option value="normal">Normal App</option>
-                <option value="menubar">Menu Bar</option>
-              </select>
-            </div>
-            <div style={rowStyle}>
-              <span style={labelStyle}>Left-Click</span>
-              <select
-                value={leftClickBehavior}
-                onChange={(e) => {
-                  const behavior = e.target.value;
-                  setLeftClickBehavior(behavior);
-                  window.electronAPI.setLeftClickBehavior(behavior);
-                }}
-                style={selectStyle}
-              >
-                <option value="switcher_window">Quick Switcher</option>
-                <option value="ai_assistant">AI Insight Chat</option>
-                <option value="pure_chat">AI Smart Chat</option>
-              </select>
-            </div>
-            <div style={rowStyle}>
               <span style={labelStyle}>Launch at Login</span>
               <label
                 style={{
@@ -439,9 +392,55 @@ const PopupDefaultExample = ({
                 />
               </label>
             </div>
-            {switcherMode !== 'sessions' && (
-              <div style={{ ...rowStyle, gap: '8px' }}>
-                <span style={labelStyle}>Working Dir</span>
+            <div style={rowStyle}>
+              <span style={labelStyle}>App Mode</span>
+              <select
+                value={appModeState}
+                onChange={(e) => {
+                  const mode = e.target.value;
+                  setAppModeState(mode);
+                  window.electronAPI.setAppMode(mode);
+                }}
+                style={selectStyle}
+              >
+                <option value="normal">Normal App</option>
+                <option value="menubar">Menu Bar</option>
+              </select>
+            </div>
+            <div style={rowStyle}>
+              <span style={labelStyle}>Left-Click <span style={{ fontSize: '9px', color: '#666' }}>(tray)</span></span>
+              <select
+                value={leftClickBehavior}
+                onChange={(e) => {
+                  const behavior = e.target.value;
+                  setLeftClickBehavior(behavior);
+                  window.electronAPI.setLeftClickBehavior(behavior);
+                }}
+                style={selectStyle}
+              >
+                <option value="switcher_window">Quick Switcher</option>
+                <option value="ai_assistant">AI Insight Chat</option>
+                <option value="pure_chat">AI Smart Chat</option>
+              </select>
+            </div>
+            <div style={rowStyle}>
+              <span style={labelStyle}>Default Tab</span>
+              <select
+                value={defaultSwitcherMode}
+                onChange={(e) => {
+                  const mode = e.target.value;
+                  setDefaultSwitcherMode(mode);
+                  window.electronAPI.setDefaultSwitcherMode(mode);
+                }}
+                style={selectStyle}
+              >
+                <option value="projects">Projects</option>
+                <option value="sessions">Sessions</option>
+                <option value="terminal">Terminal</option>
+              </select>
+            </div>
+            <div style={{ ...rowStyle, gap: '8px' }}>
+              <span style={labelStyle}>Working Dir <span style={{ fontSize: '9px', color: '#666' }}>(projects/term)</span></span>
                 <div style={{ color: '#aaa', fontSize: '12px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1, textAlign: 'right' }}>
                   {workingFolderPath || 'None'}
                 </div>
@@ -452,10 +451,9 @@ const PopupDefaultExample = ({
                 >
                   📁
                 </button>
-              </div>
-            )}
+            </div>
             <div style={rowStyle}>
-              <span style={labelStyle}>Launch Terminal</span>
+              <span style={labelStyle}>Launch Terminal <span style={{ fontSize: '9px', color: '#666' }}>(sessions)</span></span>
               <select
                 value={sessionTerminalApp}
                 onChange={(e) => {
@@ -466,7 +464,7 @@ const PopupDefaultExample = ({
                 style={selectStyle}
               >
                 <option value="iterm2">iTerm2</option>
-                <option value="terminal">Terminal</option>
+                <option value="terminal">Terminal.app</option>
                 <option value="ghostty">Ghostty</option>
                 <option value="cmux">cmux</option>
                 <option value="vscode">VS Code</option>
@@ -474,7 +472,7 @@ const PopupDefaultExample = ({
             </div>
             {(sessionTerminalApp === 'iterm2' || sessionTerminalApp === 'terminal' || sessionTerminalApp === 'ghostty') && (
               <div style={rowStyle}>
-                <span style={labelStyle}>Launch Mode</span>
+                <span style={labelStyle}>Launch Mode <span style={{ fontSize: '9px', color: '#666' }}>(tab/window)</span></span>
                 <select
                   value={sessionTerminalMode}
                   onChange={(e) => {
@@ -490,7 +488,7 @@ const PopupDefaultExample = ({
               </div>
             )}
             <div style={{ ...rowStyle, gap: '6px' }}>
-              <span style={labelStyle}>IDE</span>
+              <span style={labelStyle}>IDE <span style={{ fontSize: '9px', color: '#666' }}>(projects)</span></span>
               <select
                 value={idePreference}
                 onChange={(e) => {
@@ -687,19 +685,6 @@ const PopupDefaultExample = ({
               </div>
             ))}
             <div style={{ borderTop: '1px solid #333', marginTop: '8px', paddingTop: '6px' }}>
-              <span style={{ fontSize: '11px', color: '#666' }}>Claude Session Launch</span>
-              {[
-                { keys: '\u2318+Enter', label: 'New Claude Session' },
-                { keys: '\u21E7+Enter', label: 'New Claude (CodeV Term)' },
-                { keys: '\u2318+Click', label: 'New Claude Session' },
-              ].map((row) => (
-                <div key={row.keys} style={{ display: 'flex', justifyContent: 'space-between', padding: '1px 0' }}>
-                  <span style={{ fontSize: '11px', color: '#888', fontFamily: 'monospace' }}>{row.keys}</span>
-                  <span style={{ fontSize: '11px', color: '#888' }}>{row.label}</span>
-                </div>
-              ))}
-            </div>
-            <div style={{ borderTop: '1px solid #333', marginTop: '6px', paddingTop: '6px' }}>
               <span style={{ fontSize: '11px', color: '#666' }}>Tab Switching</span>
               {[
                 { keys: 'Tab', label: 'Projects \u2194 Sessions' },
@@ -708,6 +693,19 @@ const PopupDefaultExample = ({
                 { keys: '\u2318+1/2/3', label: 'Jump to Tab' },
               ].map((row) => (
                 <div key={row.keys} style={{ display: 'flex', justifyContent: 'space-between', padding: '2px 0' }}>
+                  <span style={{ fontSize: '11px', color: '#888', fontFamily: 'monospace' }}>{row.keys}</span>
+                  <span style={{ fontSize: '11px', color: '#888' }}>{row.label}</span>
+                </div>
+              ))}
+            </div>
+            <div style={{ borderTop: '1px solid #333', marginTop: '6px', paddingTop: '6px' }}>
+              <span style={{ fontSize: '11px', color: '#666' }}>Claude Session Launch <span style={{ color: '#555' }}>(in Projects)</span></span>
+              {[
+                { keys: '\u2318+Enter', label: 'New Claude Session' },
+                { keys: '\u21E7+Enter', label: 'New Claude (CodeV Term)' },
+                { keys: '\u2318+Click', label: 'New Claude Session' },
+              ].map((row) => (
+                <div key={row.keys} style={{ display: 'flex', justifyContent: 'space-between', padding: '1px 0' }}>
                   <span style={{ fontSize: '11px', color: '#888', fontFamily: 'monospace' }}>{row.keys}</span>
                   <span style={{ fontSize: '11px', color: '#888' }}>{row.label}</span>
                 </div>

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -328,6 +328,7 @@ const PopupDefaultExample = ({
               <button
                 key={tab}
                 onClick={() => {
+                  if (tab === settingsTab) return;
                   // Resume any paused shortcut when switching away from Shortcuts tab
                   if (editingShortcut) {
                     window.electronAPI.resumeShortcut(editingShortcut);

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -327,7 +327,15 @@ const PopupDefaultExample = ({
             {(['general', 'sessions', 'shortcuts'] as const).map((tab) => (
               <button
                 key={tab}
-                onClick={() => setSettingsTab(tab)}
+                onClick={() => {
+                  // Resume any paused shortcut when switching away from Shortcuts tab
+                  if (editingShortcut) {
+                    window.electronAPI.resumeShortcut(editingShortcut);
+                    setEditingShortcut(null);
+                    setShortcutError('');
+                  }
+                  setSettingsTab(tab);
+                }}
                 style={{
                   padding: '6px 12px',
                   fontSize: '12px',

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -33,6 +33,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getAppMode: () => ipcRenderer.invoke('get-app-mode'),
   setAppMode: (mode: string) => ipcRenderer.send('set-app-mode', mode),
   onAppModeChanged: (callback: any) => ipcRenderer.on('app-mode-changed', callback),
+  onShortcutsUpdated: (callback: any) => ipcRenderer.on('shortcuts-updated', callback),
   getSessionTerminalApp: () => ipcRenderer.invoke('get-session-terminal-app'),
   setSessionTerminalApp: (app: string) => ipcRenderer.send('set-session-terminal-app', app),
   getSessionTerminalMode: () => ipcRenderer.invoke('get-session-terminal-mode'),

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -30,6 +30,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   installUpdate: () => ipcRenderer.send('install-update'),
   getUpdateStatus: () => ipcRenderer.invoke('get-update-status'),
   onUpdateStatus: (callback: any) => ipcRenderer.on('update-status', callback),
+  getAppMode: () => ipcRenderer.invoke('get-app-mode'),
+  setAppMode: (mode: string) => ipcRenderer.send('set-app-mode', mode),
   getSessionTerminalApp: () => ipcRenderer.invoke('get-session-terminal-app'),
   setSessionTerminalApp: (app: string) => ipcRenderer.send('set-session-terminal-app', app),
   getSessionTerminalMode: () => ipcRenderer.invoke('get-session-terminal-mode'),

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -32,6 +32,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   onUpdateStatus: (callback: any) => ipcRenderer.on('update-status', callback),
   getAppMode: () => ipcRenderer.invoke('get-app-mode'),
   setAppMode: (mode: string) => ipcRenderer.send('set-app-mode', mode),
+  onAppModeChanged: (callback: any) => ipcRenderer.on('app-mode-changed', callback),
   getSessionTerminalApp: () => ipcRenderer.invoke('get-session-terminal-app'),
   setSessionTerminalApp: (app: string) => ipcRenderer.send('set-session-terminal-app', app),
   getSessionTerminalMode: () => ipcRenderer.invoke('get-session-terminal-mode'),

--- a/src/switcher-ui.tsx
+++ b/src/switcher-ui.tsx
@@ -693,6 +693,12 @@ function SwitcherApp() {
         setTimeout(() => setModeBanner(null), 6000);
       }
     });
+    window.electronAPI.onShortcutsUpdated((_event: any, s: any) => {
+      if (s?.quickSwitcher) {
+        const display = s.quickSwitcher.replace('Command', 'Cmd').replace('Control', 'Ctrl').replace(/\+/g, '+');
+        setQuickSwitcherShortcut(display);
+      }
+    });
     window.electronAPI.onAppModeChanged((_event: any, mode: string) => {
       setCurrentAppMode(mode);
       // Show banner on mode change

--- a/src/switcher-ui.tsx
+++ b/src/switcher-ui.tsx
@@ -363,6 +363,7 @@ function SwitcherApp() {
   const [currentAppMode, setCurrentAppMode] = useState('menubar');
   const [modeBanner, setModeBanner] = useState<string | null>(null);
   const [quickSwitcherShortcut, setQuickSwitcherShortcut] = useState('');
+  const bannerTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const updateWorkingPathUIAndList = async (path: string) => {
     setWorkingFolderPath(path);
@@ -674,40 +675,44 @@ function SwitcherApp() {
     // Load shortcut for display
     window.electronAPI.getShortcuts().then((s: any) => {
       if (s?.quickSwitcher) {
-        // Convert Electron accelerator to display format
         const display = s.quickSwitcher
           .replace('Command', 'Cmd')
           .replace('Control', 'Ctrl')
           .replace(/\+/g, '+');
         setQuickSwitcherShortcut(display);
+        shortcutDisplay = display;
       }
     });
 
+    const showBanner = (msg: string, durationMs = 5000) => {
+      if (bannerTimeoutRef.current) clearTimeout(bannerTimeoutRef.current);
+      setModeBanner(msg);
+      bannerTimeoutRef.current = setTimeout(() => setModeBanner(null), durationMs);
+    };
+
     // Listen for app mode changes to enable/disable drag
+    let shortcutDisplay = ''; // will be set by getShortcuts
     window.electronAPI.getAppMode().then((mode: string) => {
       const m = mode || 'normal';
       setCurrentAppMode(m);
-      // Show banner on first launch for new users
       if (m === 'normal') {
-        setModeBanner('Normal App mode — drag to reposition. Switch to Menu Bar mode in Settings.');
-        setTimeout(() => setModeBanner(null), 6000);
+        showBanner('Normal App mode — drag to reposition. Switch to Menu Bar mode in Settings.', 6000);
       }
     });
     window.electronAPI.onShortcutsUpdated((_event: any, s: any) => {
       if (s?.quickSwitcher) {
-        const display = s.quickSwitcher.replace('Command', 'Cmd').replace('Control', 'Ctrl').replace(/\+/g, '+');
-        setQuickSwitcherShortcut(display);
+        shortcutDisplay = s.quickSwitcher.replace('Command', 'Cmd').replace('Control', 'Ctrl').replace(/\+/g, '+');
+        setQuickSwitcherShortcut(shortcutDisplay);
       }
     });
     window.electronAPI.onAppModeChanged((_event: any, mode: string) => {
       setCurrentAppMode(mode);
-      // Show banner on mode change
+      const key = shortcutDisplay || 'Cmd+Ctrl+R';
       if (mode === 'normal') {
-        setModeBanner('Switched to Normal App mode — window stays visible and is draggable.');
+        showBanner('Switched to Normal App mode — window stays visible and is draggable.');
       } else {
-        setModeBanner('Switched to Menu Bar mode — window auto-hides. Use Cmd+Ctrl+R to toggle.');
+        showBanner(`Switched to Menu Bar mode — window auto-hides. Use ${key} to toggle.`);
       }
-      setTimeout(() => setModeBanner(null), 5000);
     });
 
     window.electronAPI.onCheckTerminalAndHide(() => {

--- a/src/switcher-ui.tsx
+++ b/src/switcher-ui.tsx
@@ -945,7 +945,7 @@ function SwitcherApp() {
           flexDirection: 'row',
           justifyContent: 'space-between',
           alignItems: 'center',
-          padding: '10px 15px',
+          padding: '8px 15px',
           borderBottom: '1px solid #333',
           backgroundColor: '#252525',
           // @ts-ignore — Electron-specific CSS property for frameless window dragging

--- a/src/switcher-ui.tsx
+++ b/src/switcher-ui.tsx
@@ -361,6 +361,7 @@ function SwitcherApp() {
   const lastAssistantFetchRef = useRef<Record<string, number>>({});
   const sessionSearchRef2 = useRef(''); // tracks current search value for use in closures
   const [currentAppMode, setCurrentAppMode] = useState('menubar');
+  const [modeBanner, setModeBanner] = useState<string | null>(null);
 
   const updateWorkingPathUIAndList = async (path: string) => {
     setWorkingFolderPath(path);
@@ -671,10 +672,23 @@ function SwitcherApp() {
 
     // Listen for app mode changes to enable/disable drag
     window.electronAPI.getAppMode().then((mode: string) => {
-      setCurrentAppMode(mode || 'menubar');
+      const m = mode || 'normal';
+      setCurrentAppMode(m);
+      // Show banner on first launch for new users
+      if (m === 'normal') {
+        setModeBanner('Normal App mode — drag to reposition. Switch to Menu Bar mode in Settings.');
+        setTimeout(() => setModeBanner(null), 6000);
+      }
     });
     window.electronAPI.onAppModeChanged((_event: any, mode: string) => {
       setCurrentAppMode(mode);
+      // Show banner on mode change
+      if (mode === 'normal') {
+        setModeBanner('Switched to Normal App mode — window stays visible and is draggable.');
+      } else {
+        setModeBanner('Switched to Menu Bar mode — window auto-hides. Use Cmd+Ctrl+R to toggle.');
+      }
+      setTimeout(() => setModeBanner(null), 5000);
     });
 
     window.electronAPI.onCheckTerminalAndHide(() => {
@@ -961,6 +975,11 @@ function SwitcherApp() {
             ) : mode === 'terminal' ? '💻' : '📂'}
           </span>
           CodeV
+          {currentAppMode && (
+            <span style={{ fontSize: '10px', color: '#666', fontWeight: 'normal', marginLeft: '6px' }}>
+              {currentAppMode === 'normal' ? 'Normal' : 'Menu Bar'}
+            </span>
+          )}
         </div>
         {/* @ts-ignore */}
         <div style={{ display: 'flex', alignItems: 'center', gap: '8px', WebkitAppRegion: 'no-drag' }}>
@@ -1052,6 +1071,28 @@ function SwitcherApp() {
           }}
         />
       </div>
+
+      {/* Mode change banner */}
+      {modeBanner && (
+        <div style={{
+          padding: '6px 15px',
+          backgroundColor: 'rgba(0, 188, 212, 0.1)',
+          borderBottom: '1px solid rgba(0, 188, 212, 0.2)',
+          fontSize: '11px',
+          color: '#8ecfda',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}>
+          <span>{modeBanner}</span>
+          <span
+            style={{ cursor: 'pointer', color: '#666', marginLeft: '8px' }}
+            onClick={() => setModeBanner(null)}
+          >
+            x
+          </span>
+        </div>
+      )}
 
       {mode !== 'terminal' && (mode === 'sessions' ? (
         <div style={{ display: 'flex', flexDirection: 'column', flex: 1, overflow: 'hidden' }}>

--- a/src/switcher-ui.tsx
+++ b/src/switcher-ui.tsx
@@ -906,6 +906,8 @@ function SwitcherApp() {
           padding: '10px 15px',
           borderBottom: '1px solid #333',
           backgroundColor: '#252525',
+          // @ts-ignore — Electron-specific CSS property for frameless window dragging
+          WebkitAppRegion: 'drag',
         }}
       >
         <div
@@ -951,7 +953,8 @@ function SwitcherApp() {
           </span>
           CodeV
         </div>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+        {/* @ts-ignore */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px', WebkitAppRegion: 'no-drag' }}>
           <div
             style={{
               display: 'flex',

--- a/src/switcher-ui.tsx
+++ b/src/switcher-ui.tsx
@@ -994,11 +994,14 @@ function SwitcherApp() {
             ) : mode === 'terminal' ? '💻' : '📂'}
           </span>
           CodeV
-          {currentAppMode && (
-            <span style={{ fontSize: '10px', color: '#666', fontWeight: 'normal', marginLeft: '6px' }}>
-              {currentAppMode === 'normal' ? 'Normal' : 'Menu Bar'}
-            </span>
-          )}
+          <span style={{ display: 'inline-flex', flexDirection: 'column', marginLeft: '8px', lineHeight: 1.2 }}>
+            <span style={{ fontSize: '11px', color: '#888', fontWeight: 'normal' }}>Dev Hub</span>
+            {currentAppMode && (
+              <span style={{ fontSize: '9px', color: '#555', fontWeight: 'normal' }}>
+                {currentAppMode === 'normal' ? 'normal mode' : 'menu bar mode'}
+              </span>
+            )}
+          </span>
         </div>
         {/* @ts-ignore */}
         <div style={{ display: 'flex', alignItems: 'center', gap: '8px', WebkitAppRegion: 'no-drag' }}>

--- a/src/switcher-ui.tsx
+++ b/src/switcher-ui.tsx
@@ -362,6 +362,7 @@ function SwitcherApp() {
   const sessionSearchRef2 = useRef(''); // tracks current search value for use in closures
   const [currentAppMode, setCurrentAppMode] = useState('menubar');
   const [modeBanner, setModeBanner] = useState<string | null>(null);
+  const [quickSwitcherShortcut, setQuickSwitcherShortcut] = useState('');
 
   const updateWorkingPathUIAndList = async (path: string) => {
     setWorkingFolderPath(path);
@@ -667,6 +668,18 @@ function SwitcherApp() {
             });
           });
         }, 300);
+      }
+    });
+
+    // Load shortcut for display
+    window.electronAPI.getShortcuts().then((s: any) => {
+      if (s?.quickSwitcher) {
+        // Convert Electron accelerator to display format
+        const display = s.quickSwitcher
+          .replace('Command', 'Cmd')
+          .replace('Control', 'Ctrl')
+          .replace(/\+/g, '+');
+        setQuickSwitcherShortcut(display);
       }
     });
 
@@ -983,6 +996,11 @@ function SwitcherApp() {
         </div>
         {/* @ts-ignore */}
         <div style={{ display: 'flex', alignItems: 'center', gap: '8px', WebkitAppRegion: 'no-drag' }}>
+          {quickSwitcherShortcut && (
+            <span style={{ fontSize: '10px', color: '#555' }}>
+              {quickSwitcherShortcut}
+            </span>
+          )}
           <div
             style={{
               display: 'flex',

--- a/src/switcher-ui.tsx
+++ b/src/switcher-ui.tsx
@@ -360,6 +360,7 @@ function SwitcherApp() {
   const allSessionsRef = useRef<any[]>([]);
   const lastAssistantFetchRef = useRef<Record<string, number>>({});
   const sessionSearchRef2 = useRef(''); // tracks current search value for use in closures
+  const [currentAppMode, setCurrentAppMode] = useState('menubar');
 
   const updateWorkingPathUIAndList = async (path: string) => {
     setWorkingFolderPath(path);
@@ -668,6 +669,14 @@ function SwitcherApp() {
       }
     });
 
+    // Listen for app mode changes to enable/disable drag
+    window.electronAPI.getAppMode().then((mode: string) => {
+      setCurrentAppMode(mode || 'menubar');
+    });
+    window.electronAPI.onAppModeChanged((_event: any, mode: string) => {
+      setCurrentAppMode(mode);
+    });
+
     window.electronAPI.onCheckTerminalAndHide(() => {
       if (modeRef.current === 'terminal') {
         window.electronAPI.hideApp();
@@ -907,7 +916,7 @@ function SwitcherApp() {
           borderBottom: '1px solid #333',
           backgroundColor: '#252525',
           // @ts-ignore — Electron-specific CSS property for frameless window dragging
-          WebkitAppRegion: 'drag',
+          WebkitAppRegion: currentAppMode === 'normal' ? 'drag' : undefined,
         }}
       >
         <div


### PR DESCRIPTION
## Summary

Add Normal App mode as an alternative to the current Menu Bar mode. New users default to Normal App mode for better discoverability.

### Normal App mode
- Window shows in Dock
- No auto-hide on blur (stays visible)
- Draggable via title bar
- `Cmd+Ctrl+R` toggles show/hide (no minimize animation)
- Window remembers position (not re-centered)
- Shows immediately on app startup

### Menu Bar mode (existing behavior)
- Hidden from Dock
- Auto-hide on blur
- Centers on screen each time
- `Cmd+Ctrl+R` toggles show/hide

### Settings
- App Mode: Normal App / Menu Bar (in General section)
- Instant switching (no restart needed)
- Switching to Menu Bar re-centers window

### UI hints
- Title bar: "CodeV Dev Hub" + mode indicator ("normal mode" / "menu bar mode") + actual shortcut key (right-aligned)
- Banner on first launch (Normal mode) and on mode switch (auto-dismiss 5-6s)
- Shortcut display syncs in real-time when changed in Settings
- Clicking Dock icon shows hidden window in Normal mode

### Settings UI redesign
- 3 tabs: General / Sessions / Shortcuts (replaces single scrollable panel)
- General: Launch at Login, App Mode, Left-Click (tray), Default Tab, Working Dir (projects/term), Launch Terminal (sessions), Launch Mode (tab/window), IDE (projects)
- Sessions: Session Preview, Session Status (hooks)
- Shortcuts: Global shortcuts (editable) + Tab Switching + Claude Session Launch (in Projects)
- Context hints on settings that only affect specific tabs
- Terminal renamed to Terminal.app in dropdown

## Test plan

- [x] Normal mode: shows in Dock
- [x] Normal mode: no auto-hide on blur
- [x] Normal mode: draggable title bar
- [x] Normal mode: `Cmd+Ctrl+R` toggles hide/show (no animation)
- [x] Normal mode: window shows on startup
- [x] Normal mode: clicking Dock icon shows hidden window
- [x] Menu Bar mode: all existing behavior preserved
- [x] Switch Normal → Menu Bar: re-centers, drag disabled
- [x] Switch Menu Bar → Normal: drag enabled
- [x] Setting persists across restart
- [x] Title bar: Dev Hub + mode indicator + shortcut
- [x] Banner on mode switch (auto-dismiss)
- [x] Shortcut display syncs on save/reset
- [x] Settings tabs: General / Sessions / Shortcuts
- [x] No scrolling needed in any settings tab
- [x] Terminal.app in dropdown

### Normal mode: what updates when unfocused (visible but not active)

| | Updates in real-time? | Mechanism |
|--|--|--|
| Status dots (working/idle/needs-attention) | Yes | fs.watch on codev-status/ |
| Final assistant message (blue text) | Yes | refreshSessionPreview() on idle |
| Final user message (amber text) | Yes | refreshSessionPreview() on idle |
| Session order (re-sort) | Yes (idle-triggered only) | refreshSessionPreview() updates lastTimestamp |
| **New session appearing** | **No** | Requires fetchClaudeSessions() (focus-triggered) |
| **Session disappearing** | **No** | Same |
| Full list re-fetch | No | Only on window re-focus |

**Known limitation**: New sessions won't appear until the window is re-focused. This is a trade-off — continuous full refresh would cause visual noise (sessions jumping around). Could be improved by detecting new sessions via fs.watch without full refresh (follow-up).

_🤖 On behalf of @grimmerk — generated with Claude Code_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable App Mode (Normal/Menu Bar) with persistent selection, Dock visibility, mode banners, draggable title bar in Normal mode, and Cmd+Ctrl+R toggle
  * Redesigned Settings with tabs (General, Sessions, Shortcuts), reduced context switching, added hints, and reorganized shortcuts UI (includes quick-launch shortcut display and resume-on-tab-switch)
  * Minor UI tweaks: reduced title bar padding and renamed Terminal entry to “Terminal.app”

* **Documentation**
  * README updated to document App Mode behavior and updated settings paths
<!-- end of auto-generated comment: release notes by coderabbit.ai -->