### PR TITLE
fix: use setActivationPolicy for proper Dock behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.0.71
+
+- Fix: use `setActivationPolicy` instead of `app.dock.hide/show` for proper Dock behavior
+  - Normal mode: Dock icon with running dot + App Switcher
+  - Menu bar mode: no Dock icon (clean accessory mode)
+  - No Dock icon flash on app launch (LSUIElement=true kept)
+- Feat: tray right-click menu mode toggle (Switch to Normal/Menu Bar Mode)
+
 ## 1.0.70
 
 - Feat: Normal App mode — window stays visible, shows in Dock, draggable

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "CodeV",
   "productName": "CodeV",
-  "version": "1.0.70",
+  "version": "1.0.71",
   "description": "Quick switcher for VS Code, Cursor, and Claude Code sessions",
   "repository": {
     "type": "git",

--- a/src/TrayGenerator.ts
+++ b/src/TrayGenerator.ts
@@ -21,6 +21,8 @@ export class TrayGenerator {
   tray: Tray;
   attachedWindow: BrowserWindow;
   onTrayClickCallback: any;
+  onToggleAppMode: (() => void) | null = null;
+  getAppMode: (() => string) | null = null;
   title: string;
   shortcuts: ShortcutSettings = {
     quickSwitcher: 'Command+Control+R',
@@ -83,7 +85,17 @@ export class TrayGenerator {
       },
     ];
 
+    const currentMode = this.getAppMode ? this.getAppMode() : 'normal';
+    const modeLabel = currentMode === 'normal' ? 'Switch to Menu Bar Mode' : 'Switch to Normal App Mode';
+
     const menu: any = [
+      {
+        label: modeLabel,
+        click: () => {
+          if (this.onToggleAppMode) this.onToggleAppMode();
+        },
+      },
+      { type: 'separator' },
       {
         label: 'Settings',
         submenu: settingsItems,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1032,9 +1032,11 @@ const trayToggleEvtHandler = async () => {
 
   // Load app mode setting early (before window creation)
   appMode = ((await settings.get('app-mode')) as 'normal' | 'menubar') || 'normal';
-  if (appMode === 'menubar') {
-    app.dock.hide();
+  if (appMode === 'normal') {
+    app.setActivationPolicy('regular');
   }
+  // LSUIElement=true in Info.plist starts as accessory (no dock icon).
+  // 'regular' adds dock icon + running dot + App Switcher.
 
   // Auto-update: check for updates via update.electronjs.org (non-MAS only)
   if (!isMAS()) {
@@ -1972,9 +1974,14 @@ ipcMain.on('set-app-mode', async (_event, mode: string) => {
   await settings.set('app-mode', newMode);
   appMode = newMode;
   if (newMode === 'menubar') {
-    app.dock.hide();
+    app.setActivationPolicy('accessory');
+    // accessory mode hides all windows — re-show after short delay
+    const win = getSwitcherWindow();
+    if (win) {
+      setTimeout(() => { win.show(); win.focus(); }, 100);
+    }
   } else {
-    await app.dock.show();
+    app.setActivationPolicy('regular');
   }
   // Notify renderer to update drag region
   const window = getSwitcherWindow();
@@ -2131,4 +2138,4 @@ ipcMain.handle('detect-active-ide-projects', async () => {
   return Array.from(folderNames);
 });
 
-// app.dock.hide() moved to async init block (after settings loaded)
+// Dock visibility managed via app.setActivationPolicy() (see set-app-mode handler)

--- a/src/main.ts
+++ b/src/main.ts
@@ -1294,6 +1294,12 @@ const trayToggleEvtHandler = async () => {
   }
 
   tray = new TrayGenerator(switcherWindow, title, trayToggleEvtHandler);
+  tray.getAppMode = () => appMode;
+  tray.onToggleAppMode = () => {
+    const newMode = appMode === 'normal' ? 'menubar' : 'normal';
+    // Reuse the same logic as the IPC handler
+    require('electron').ipcMain.emit('set-app-mode', {}, newMode);
+  };
 
   // https://www.electronjs.org/docs/latest/tutorial/keyboard-shortcuts#global-shortcuts
 


### PR DESCRIPTION
## Summary

Replace `app.dock.hide()/show()` with `app.setActivationPolicy()` for proper Dock behavior in Normal App mode.

### Before (app.dock.hide/show)
- Normal mode: Dock icon appears but **no running dot**, shows on right side
- Menu bar mode: `dock.hide()` only removes dot, icon may persist if manually pinned
- Known Electron bugs with `dock.hide()` (breaks `app.hide()`, conflicts with `setVisibleOnAllWorkspaces`)

### After (setActivationPolicy)
- Normal mode: `'regular'` — proper Dock icon with running dot, App Switcher visible
- Menu bar mode: `'accessory'` — no Dock icon at all (same as LSUIElement)
- `LSUIElement=true` kept in Info.plist to prevent Dock icon flash on app launch

### Caveat
- Switching to `'accessory'` hides all windows — re-shown with 100ms delay
- `setActivationPolicy` is a standard macOS API (`NSApplicationActivationPolicy`), not a hack

### Tray menu mode toggle
- Right-click tray icon → "Switch to Menu Bar Mode" / "Switch to Normal App Mode"
- Uses same logic as Settings toggle (IPC handler)

## Test plan

- [ ] Normal mode: Dock icon with running dot (left side)
- [ ] Normal mode: visible in App Switcher (Cmd+Tab)
- [ ] Menu bar mode: no Dock icon
- [ ] Switch Normal → Menu Bar: icon disappears, window re-shows
- [ ] Switch Menu Bar → Normal: icon appears with dot
- [ ] App launch in Normal mode: no Dock icon flash
- [ ] Tray right-click → mode toggle works in both directions

_🤖 On behalf of @grimmerk — generated with Claude Code_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved dock icon flashing issue: eliminated unwanted Dock icon behavior on application launch when operating in Menu Bar mode, providing a cleaner startup experience

* **New Features**
  * Added application mode toggle to the tray context menu, allowing users to easily switch between Normal Application Mode and Menu Bar Mode without requiring an application restart

<!-- end of auto-generated comment: release notes by coderabbit.ai -->