### PR TITLE
fix: window-toggle actions focus when covered (Cmd+Ctrl+R/T, tray click)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.72
+
+- Fix: `Cmd+Ctrl+R` brings window to front when covered by another app
+  - Previously: visible-but-unfocused first press hid the window
+  - Now: visible+unfocused → focus to top; visible+focused → hide
+
 ## 1.0.71
 
 - Fix: use `setActivationPolicy` instead of `app.dock.hide/show` for proper Dock behavior

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## 1.0.72
 
-- Fix: `Cmd+Ctrl+R` brings window to front when covered by another app
+- Fix: window-toggle actions bring window to front when covered by another app (Normal mode)
+  - `Cmd+Ctrl+R` (Quick Switcher), `Cmd+Ctrl+T` (Terminal), and tray left-click
   - Previously: visible-but-unfocused first press hid the window
-  - Now: visible+unfocused → focus to top; visible+focused → hide
+  - Now: visible+unfocused → focus to top; visible+focused → hide (or toggle Terminal tab)
+  - Menu bar mode unaffected (`onBlur` auto-hide makes the state unreachable)
 
 ## 1.0.71
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "CodeV",
   "productName": "CodeV",
-  "version": "1.0.71",
+  "version": "1.0.72",
   "description": "Quick switcher for VS Code, Cursor, and Claude Code sessions",
   "repository": {
     "type": "git",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1327,10 +1327,22 @@ const trayToggleEvtHandler = async () => {
       const window = getSwitcherWindow();
       
       if (window && window.isVisible() && !window.isMinimized()) {
-        if (isDebug) {
-          console.log('Switcher window visible, hiding it');
+        if (window.isFocused()) {
+          if (isDebug) {
+            console.log('Switcher window visible and focused, hiding it');
+          }
+          hideSwitcherWindow();
+        } else {
+          // Visible but covered by another app — bring to top instead of hiding
+          if (isDebug) {
+            console.log('Switcher window visible but unfocused, bringing to front');
+          }
+          if (appMode === 'normal') {
+            app.focus({ steal: true });
+          }
+          window.show();
+          window.focus();
         }
-        hideSwitcherWindow();
       } else if (window) {
         if (isDebug) {
           console.log('Switcher window exists but hidden, showing it');

--- a/src/main.ts
+++ b/src/main.ts
@@ -1002,12 +1002,24 @@ const trayToggleEvtHandler = async () => {
       showSwitcherWindow();
     } else {
       const window = getSwitcherWindow();
-      
-      if (window && window.isVisible()) {
-        if (isDebug) {
-          console.log('is visible, to hide');
+
+      if (window && window.isVisible() && !window.isMinimized()) {
+        if (window.isFocused()) {
+          if (isDebug) {
+            console.log('is visible and focused, to hide');
+          }
+          hideSwitcherWindow();
+        } else {
+          // Visible but covered by another app — bring to front instead of hiding
+          if (isDebug) {
+            console.log('is visible but unfocused, bringing to front');
+          }
+          if (appMode === 'normal') {
+            app.focus({ steal: true });
+          }
+          window.show();
+          window.focus();
         }
-        hideSwitcherWindow();
       } else if (window) {
         if (isDebug) {
           console.log('is not visible, to show');
@@ -1638,9 +1650,19 @@ const trayToggleEvtHandler = async () => {
       switcherWindow = createSwitcherWindow();
     }
     const window = getSwitcherWindow();
-    if (window && window.isVisible()) {
-      // If already showing Terminal tab, hide; otherwise switch to Terminal
-      window.webContents.send('check-terminal-and-hide');
+    if (window && window.isVisible() && !window.isMinimized()) {
+      if (window.isFocused()) {
+        // If already showing Terminal tab, hide; otherwise switch to Terminal
+        window.webContents.send('check-terminal-and-hide');
+      } else {
+        // Visible but covered — bring to front and switch to Terminal tab
+        if (appMode === 'normal') {
+          app.focus({ steal: true });
+        }
+        window.show();
+        window.focus();
+        window.webContents.send('switch-to-terminal');
+      }
     } else if (window) {
       window.webContents.send('switch-to-terminal');
       showSwitcherWindow();


### PR DESCRIPTION
## Summary

Fix window-toggle actions in Normal App mode when the CodeV window is visible but covered by another app.

### Affected actions

| Action | Callback | Before | After |
|---|---|---|---|
| `Cmd+Ctrl+R` | `quickSwitcherCallback` | hides | brings to front |
| Tray left-click | `trayToggleEvtHandler` | hides | brings to front |
| `Cmd+Ctrl+T` | `terminalCallback` | hides (or no-op tab switch) | brings to front + switches to Terminal tab |

### Three-state logic

| State | Action |
|---|---|
| Hidden / minimized | show + focus (unchanged) |
| Visible AND focused | hide / toggle (unchanged) |
| Visible but unfocused (covered) | `app.focus({ steal: true })` + `window.show()` + `window.focus()` (**new**) |

For `Cmd+Ctrl+T`, the visible-but-unfocused branch also sends `switch-to-terminal` so the user lands on the Terminal tab after the window comes to front (matches the user intent of "I want to use the terminal"). The visible-and-focused branch keeps the existing renderer-side toggle (`check-terminal-and-hide`).

Also adds the missing `!window.isMinimized()` check to both `trayToggleEvtHandler` and `terminalCallback` for consistency with `quickSwitcherCallback`.

### Why menu bar mode is unaffected

In menu bar mode, `onBlur` auto-hides the window the moment focus is lost (`src/main.ts:267-271`), so the "visible but unfocused" state can't occur. The new `app.focus({ steal: true })` call is also gated to `appMode === 'normal'` as a safeguard — accessory apps shouldn't steal app-level focus.

## Test plan

### Normal mode
- [x] `Cmd+Ctrl+R`: cover with another app → single press brings CodeV to front
- [x] `Cmd+Ctrl+R`: on top + focused → hides
- [x] `Cmd+Ctrl+R`: hidden → shows + focuses
- [ ] Tray left-click: cover with another app → single click brings CodeV to front
- [ ] Tray left-click: on top + focused → hides
- [ ] `Cmd+Ctrl+T`: cover with another app → brings to front + lands on Terminal tab
- [ ] `Cmd+Ctrl+T`: on top + focused + already on Terminal tab → hides
- [ ] `Cmd+Ctrl+T`: on top + focused + on other tab → switches to Terminal tab

### Menu bar mode
- [ ] `Cmd+Ctrl+R`: behavior unchanged (visible → hide, hidden → show)
- [ ] Tray left-click: behavior unchanged
- [ ] `Cmd+Ctrl+T`: behavior unchanged

_🤖 On behalf of @grimmerk — generated with Claude Code_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Window-toggle actions (Quick Switcher, Terminal, and tray left-click) now bring windows to the front when visible but unfocused, instead of hiding them on the first press
  * Windows hide as expected when already visible and focused
  * Menu Bar mode behavior remains unchanged

<!-- end of auto-generated comment: release notes by coderabbit.ai -->