### PR TITLE
feat: embedded terminal search (Cmd+F)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.0.73
+
+- Feat: embedded terminal search (`Cmd+F`)
+  - Search overlay with previous/next/close buttons and match counter
+  - `Enter` for next match, `Shift+Enter` for previous, `Escape` to close
+  - Powered by `@xterm/addon-search`
+
 ## 1.0.72
 
 - Fix: window-toggle actions bring window to front when covered by another app (Normal mode)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "CodeV",
   "productName": "CodeV",
-  "version": "1.0.72",
+  "version": "1.0.73",
   "description": "Quick switcher for VS Code, Cursor, and Claude Code sessions",
   "repository": {
     "type": "git",
@@ -73,6 +73,7 @@
     "@nestjs/platform-express": "^10.0.3",
     "@prisma/client": "^4.16.1",
     "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-search": "^0.16.0",
     "@xterm/xterm": "^6.0.0",
     "axios": "1.14.0",
     "better-sqlite3": "^12.8.0",

--- a/src/terminal-tab.tsx
+++ b/src/terminal-tab.tsx
@@ -1,14 +1,72 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
+import { SearchAddon } from '@xterm/addon-search';
 import '@xterm/xterm/css/xterm.css';
+
+const SEARCH_DECORATIONS = {
+  matchBackground: '#515C6A',
+  matchBorder: '#515C6A',
+  matchOverviewRuler: '#d186167e',
+  activeMatchBackground: '#A8AC94',
+  activeMatchBorder: '#A8AC94',
+  activeMatchColorOverviewRuler: '#A8AC94',
+};
+
+const searchButtonStyle: React.CSSProperties = {
+  width: '20px',
+  height: '20px',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  background: 'transparent',
+  border: 'none',
+  borderRadius: '2px',
+  color: '#cccccc',
+  fontSize: '12px',
+  cursor: 'pointer',
+  padding: 0,
+  lineHeight: 1,
+};
 
 const TerminalTab = ({ visible, onLaunchExternal }: { visible: boolean; onLaunchExternal?: () => void }) => {
   const termRef = useRef<HTMLDivElement>(null);
   const xtermRef = useRef<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
+  const searchAddonRef = useRef<SearchAddon | null>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const spawnedRef = useRef(false);
   const initializedRef = useRef(false);
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchResult, setSearchResult] = useState<{ resultIndex: number; resultCount: number } | null>(null);
+
+  const closeSearch = useCallback(() => {
+    setSearchOpen(false);
+    setSearchQuery('');
+    setSearchResult(null);
+    searchAddonRef.current?.clearDecorations();
+    xtermRef.current?.focus();
+  }, []);
+
+  const findNext = useCallback((query: string) => {
+    if (!searchAddonRef.current) return;
+    if (!query) {
+      searchAddonRef.current.clearDecorations();
+      setSearchResult(null);
+      return;
+    }
+    searchAddonRef.current.findNext(query, {
+      decorations: SEARCH_DECORATIONS,
+    });
+  }, []);
+
+  const findPrevious = useCallback((query: string) => {
+    if (!searchAddonRef.current || !query) return;
+    searchAddonRef.current.findPrevious(query, {
+      decorations: SEARCH_DECORATIONS,
+    });
+  }, []);
 
   // Initialize xterm once when first visible
   useEffect(() => {
@@ -29,13 +87,29 @@ const TerminalTab = ({ visible, onLaunchExternal }: { visible: boolean; onLaunch
     });
 
     const fitAddon = new FitAddon();
+    const searchAddon = new SearchAddon();
     term.loadAddon(fitAddon);
+    term.loadAddon(searchAddon);
     term.open(termRef.current);
+
+    searchAddon.onDidChangeResults((result) => {
+      setSearchResult(result);
+    });
 
     // Let tab-switching shortcuts pass through to parent
     term.attachCustomKeyEventHandler((e) => {
       if (e.metaKey && ['1', '2', '3', '[', ']'].includes(e.key)) return false;
       if (e.ctrlKey && e.key === 'Tab') return false;
+      // Cmd+F → open search overlay (handled in React, not in PTY)
+      if (e.type === 'keydown' && e.metaKey && e.key === 'f') {
+        setSearchOpen(true);
+        // Defer focus until React renders the input
+        setTimeout(() => {
+          searchInputRef.current?.focus();
+          searchInputRef.current?.select();
+        }, 0);
+        return false;
+      }
       // Cmd+←/→ → beginning/end of line
       if (e.type === 'keydown' && e.metaKey && e.key === 'ArrowLeft') { term.input('\x01'); return false; }
       if (e.type === 'keydown' && e.metaKey && e.key === 'ArrowRight') { term.input('\x05'); return false; }
@@ -62,6 +136,7 @@ const TerminalTab = ({ visible, onLaunchExternal }: { visible: boolean; onLaunch
 
     xtermRef.current = term;
     fitAddonRef.current = fitAddon;
+    searchAddonRef.current = searchAddon;
 
     // Handle container resize
     const resizeObserver = new ResizeObserver(() => {
@@ -104,6 +179,100 @@ const TerminalTab = ({ visible, onLaunchExternal }: { visible: boolean; onLaunch
           overflow: 'hidden',
         }}
       />
+      {searchOpen && (
+        <div
+          style={{
+            position: 'absolute',
+            top: '6px',
+            right: '8px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '4px',
+            backgroundColor: '#252526',
+            border: '1px solid #454545',
+            borderRadius: '3px',
+            padding: '4px 6px',
+            zIndex: 20,
+            fontSize: '12px',
+            color: '#cccccc',
+            boxShadow: '0 2px 8px rgba(0, 0, 0, 0.4)',
+          }}
+        >
+          <input
+            ref={searchInputRef}
+            type="text"
+            value={searchQuery}
+            placeholder="Find"
+            onChange={(e) => {
+              setSearchQuery(e.target.value);
+              findNext(e.target.value);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') {
+                e.preventDefault();
+                closeSearch();
+              } else if (e.key === 'Enter') {
+                e.preventDefault();
+                if (e.shiftKey) findPrevious(searchQuery);
+                else findNext(searchQuery);
+              }
+            }}
+            style={{
+              width: '180px',
+              padding: '2px 6px',
+              backgroundColor: '#3c3c3c',
+              border: '1px solid #3c3c3c',
+              borderRadius: '2px',
+              color: '#cccccc',
+              fontSize: '12px',
+              outline: 'none',
+            }}
+            onFocus={(e) => { e.currentTarget.style.borderColor = '#007fd4'; }}
+            onBlur={(e) => { e.currentTarget.style.borderColor = '#3c3c3c'; }}
+          />
+          <span
+            style={{
+              minWidth: '52px',
+              textAlign: 'center',
+              fontSize: '11px',
+              color: searchQuery && searchResult && searchResult.resultCount === 0 ? '#f48771' : '#888',
+            }}
+          >
+            {searchQuery
+              ? searchResult && searchResult.resultCount > 0
+                ? `${searchResult.resultIndex + 1} of ${searchResult.resultCount}`
+                : 'No results'
+              : ''}
+          </span>
+          <button
+            onClick={() => findPrevious(searchQuery)}
+            title="Previous match (Shift+Enter)"
+            style={searchButtonStyle}
+            onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = '#3c3c3c'; }}
+            onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = 'transparent'; }}
+          >
+            ↑
+          </button>
+          <button
+            onClick={() => findNext(searchQuery)}
+            title="Next match (Enter)"
+            style={searchButtonStyle}
+            onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = '#3c3c3c'; }}
+            onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = 'transparent'; }}
+          >
+            ↓
+          </button>
+          <button
+            onClick={closeSearch}
+            title="Close (Escape)"
+            style={searchButtonStyle}
+            onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = '#3c3c3c'; }}
+            onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = 'transparent'; }}
+          >
+            ✕
+          </button>
+        </div>
+      )}
       <button
         onClick={() => onLaunchExternal?.()}
         title="Open new Claude session in external terminal (uses current working directory)"

--- a/src/terminal-tab.tsx
+++ b/src/terminal-tab.tsx
@@ -34,6 +34,7 @@ const TerminalTab = ({ visible, onLaunchExternal }: { visible: boolean; onLaunch
   const xtermRef = useRef<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
   const searchAddonRef = useRef<SearchAddon | null>(null);
+  const searchResultDisposableRef = useRef<{ dispose: () => void } | null>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const spawnedRef = useRef(false);
   const initializedRef = useRef(false);
@@ -92,7 +93,7 @@ const TerminalTab = ({ visible, onLaunchExternal }: { visible: boolean; onLaunch
     term.loadAddon(searchAddon);
     term.open(termRef.current);
 
-    searchAddon.onDidChangeResults((result) => {
+    searchResultDisposableRef.current = searchAddon.onDidChangeResults((result) => {
       setSearchResult(result);
     });
 
@@ -169,6 +170,14 @@ const TerminalTab = ({ visible, onLaunchExternal }: { visible: boolean; onLaunch
     xtermRef.current.focus();
   }, [visible]);
 
+  // Dispose search result listener on unmount
+  useEffect(() => {
+    return () => {
+      searchResultDisposableRef.current?.dispose();
+      searchResultDisposableRef.current = null;
+    };
+  }, []);
+
   return (
     <div style={{ width: '100%', height: '100%', position: 'relative', backgroundColor: '#1e1e1e' }}>
       <div
@@ -203,6 +212,7 @@ const TerminalTab = ({ visible, onLaunchExternal }: { visible: boolean; onLaunch
             type="text"
             value={searchQuery}
             placeholder="Find"
+            aria-label="Find in terminal"
             onChange={(e) => {
               setSearchQuery(e.target.value);
               findNext(e.target.value);
@@ -231,6 +241,7 @@ const TerminalTab = ({ visible, onLaunchExternal }: { visible: boolean; onLaunch
             onBlur={(e) => { e.currentTarget.style.borderColor = '#3c3c3c'; }}
           />
           <span
+            aria-live="polite"
             style={{
               minWidth: '52px',
               textAlign: 'center',
@@ -240,13 +251,18 @@ const TerminalTab = ({ visible, onLaunchExternal }: { visible: boolean; onLaunch
           >
             {searchQuery
               ? searchResult && searchResult.resultCount > 0
-                ? `${searchResult.resultIndex + 1} of ${searchResult.resultCount}`
+                ? // resultIndex is -1 when matches exceed the highlight limit (default 1000).
+                  // Show just the count in that case, otherwise show "current of total".
+                  searchResult.resultIndex < 0
+                  ? `${searchResult.resultCount}+ results`
+                  : `${searchResult.resultIndex + 1} of ${searchResult.resultCount}`
                 : 'No results'
               : ''}
           </span>
           <button
             onClick={() => findPrevious(searchQuery)}
             title="Previous match (Shift+Enter)"
+            aria-label="Previous match"
             style={searchButtonStyle}
             onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = '#3c3c3c'; }}
             onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = 'transparent'; }}
@@ -256,6 +272,7 @@ const TerminalTab = ({ visible, onLaunchExternal }: { visible: boolean; onLaunch
           <button
             onClick={() => findNext(searchQuery)}
             title="Next match (Enter)"
+            aria-label="Next match"
             style={searchButtonStyle}
             onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = '#3c3c3c'; }}
             onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = 'transparent'; }}
@@ -265,6 +282,7 @@ const TerminalTab = ({ visible, onLaunchExternal }: { visible: boolean; onLaunch
           <button
             onClick={closeSearch}
             title="Close (Escape)"
+            aria-label="Close search"
             style={searchButtonStyle}
             onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = '#3c3c3c'; }}
             onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = 'transparent'; }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2068,6 +2068,11 @@
   resolved "https://registry.yarnpkg.com/@xterm/addon-fit/-/addon-fit-0.11.0.tgz#ba4778b69fcc9044a060c2176bbe077657d7b37e"
   integrity sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==
 
+"@xterm/addon-search@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@xterm/addon-search/-/addon-search-0.16.0.tgz#ddadcbc6e556e45fc4b153f8a0efdf2aa1456b82"
+  integrity sha512-9OeuBFu0/uZJPu+9AHKY6g/w0Czyb/Ut0A5t79I4ULoU4IfU5BEpPFVGQxP4zTTMdfZEYkVIRYbHBX1xWwjeSA==
+
 "@xterm/xterm@^6.0.0":
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/@xterm/xterm/-/xterm-6.0.0.tgz#93637b0f2ee3a70718b5746a27c9c506af16745b"


### PR DESCRIPTION
## Summary

Add `Cmd+F` search to the embedded terminal, matching VS Code's terminal behavior. Powered by `@xterm/addon-search`.

### UX

- `Cmd+F` opens a search overlay (top-right of the terminal)
- The overlay has: input field, match counter, previous/next/close buttons
- Typing searches incrementally as you go
- `Enter` jumps to next match, `Shift+Enter` to previous, `Escape` closes
- Empty input shows nothing; query with no matches shows "No results" in red
- Highlight colors match VS Code's dark theme (`#515C6A` for matches, `#A8AC94` for active match)

### Why xterm.js doesn't ship a search UI

xterm.js (the library VS Code's terminal also uses) only provides search **APIs** through `@xterm/addon-search` — `findNext()`, `findPrevious()`, `onDidChangeResults`. The UI is the host app's responsibility. This PR builds a small React overlay that calls into the addon.

## Changes

- `package.json` — add `@xterm/addon-search@^0.16.0`
- `src/terminal-tab.tsx`:
  - Load `SearchAddon`
  - Intercept `Cmd+F` in `attachCustomKeyEventHandler` (returns `false` so the keystroke doesn't reach the PTY)
  - Subscribe to `onDidChangeResults` for live match count
  - Render overlay (`searchOpen` state) with input + counter + buttons
  - `closeSearch()` clears decorations and refocuses the terminal
- `CHANGELOG.md` + version bump to 1.0.73

## Test plan

- [x] `Cmd+F` opens the search overlay
- [x] Typing searches incrementally
- [x] `Enter` / `Shift+Enter` cycle through matches
- [x] `Escape` closes the overlay and refocuses the terminal
- [x] Match counter updates live
- [x] No results → shows "No results" in red
- [ ] Search overlay doesn't intercept `Cmd+F` outside the Terminal tab
- [ ] Existing terminal shortcuts (`Cmd+K` clear, `Shift+Enter` multiline, `Cmd+←/→`) still work

_🤖 On behalf of @grimmerk — generated with Claude Code_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `Cmd+F` search to the embedded terminal with a lightweight overlay and keyboard navigation, matching VS Code behavior. Uses `@xterm/addon-search` for search, decorations, and live result counts.

- **New Features**
  - `Cmd+F` opens a search overlay with input, match counter, and prev/next/close; incremental search as you type.
  - `Enter` next, `Shift+Enter` previous, `Escape` closes; highlights match VS Code dark theme and the keystroke isn’t sent to the PTY.

- **Bug Fixes**
  - Show “N+ results” when matches exceed the add-on’s highlight limit.
  - Dispose `onDidChangeResults` listener on unmount; add ARIA labels to input/buttons and aria-live to the counter.

<sup>Written for commit c4392ba6be2eef18efb576543a6086e9d9562f38. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Embedded terminal search accessible with Cmd+F.
  * Search overlay with input, match counter, and previous/next/close controls.
  * Keyboard navigation: Enter = next, Shift+Enter = previous, Escape = close.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->