### PR TITLE
feat: launch Claude session as git worktree (⌘+Shift+Enter)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 1.0.75
+
+- Feat: Launch new Claude session as a git worktree from the Projects tab
+  - Press `⌘+Shift+Enter` on a project → dialog asks for branch name (optional)
+  - With a name: runs `claude -w "<name>" -n "<name>"` in the configured terminal
+  - Without a name: behaves like the existing `⌘+Enter` (normal session)
+  - The `-n` flag also sets a custom title so Ghostty's title-match can locate
+    the right tab when switching back (Ghostty has no per-tab TTY exposure).
+- Feat: worktree-aware session display
+  - Worktree session paths (`<repo>/.claude/worktrees/<name>`) now show the
+    parent repo name (e.g., `codev`) with a small `WT` badge, instead of the
+    worktree folder name (e.g., `test-worktree-4`).
+  - New `parseWorktreePath()` helper + `isWorktree` / `parentRepo` fields on
+    `ClaudeSession`.
+- Fix: Ghostty session-switching no longer "jumps to the wrong window" on
+  match miss
+  - The `activate` AppleScript call is now inside the success branch, so we
+    don't bring Ghostty forward when no matching tab is found.
+  - Benefits all session switches, not just worktrees.
+
 ## 1.0.74
 
 - Fix: session status dot stuck on purple for sessions with large responses (#116)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Press `⌃+⌘+R` or click the menu bar icon to launch the Quick Switcher. Searc
 - Supports VS Code and Cursor — switch between them in Settings → General → IDE
 - Remove items from the recent list by hovering and clicking "x"
 - **Quick-launch Claude session**: `⌘+Enter` to launch a new Claude Code session in the configured terminal, `⇧+Enter` to launch in CodeV's embedded terminal, `⌘+Click` as mouse alternative
+- **Launch as git worktree**: `⌘+Shift+Enter` opens a small dialog where you enter a branch name. CodeV launches `claude -w "<name>" -n "<name>"` so Claude creates a fresh worktree at `<repo>/.claude/worktrees/<name>`. Leaving the name empty falls back to a normal session. Worktree sessions show the parent project name with a `WT` badge in the Sessions list.
 
 ### Claude Code Session Switching
 

--- a/docs/claude-session-integration-design.md
+++ b/docs/claude-session-integration-design.md
@@ -601,6 +601,24 @@ The `project` field still holds the original worktree path so resume / cwd match
 
 When a `-w` session exits without uncommitted changes, Claude CLI may remove the worktree directory. The session JSONL is stored at `~/.claude/projects/<encoded>/<uuid>.jsonl` (independent of the worktree directory) so `claude --resume <uuid>` still works — the cwd shown in the session header just reflects wherever resume was invoked from. No special handling needed in codev.
 
+### Detection is path-based, not launch-based
+
+`parseWorktreePath()` recognizes any path matching `<repo>/.claude/worktrees/<name>` — regardless of who created the worktree. This means codev shows the `WT` badge for:
+
+- Sessions launched via codev's `⌘+Shift+Enter` (this PR's feature)
+- Sessions where the user manually ran `claude -w <name>` from a terminal
+- Sessions created by other tools (c9watch, older claude-control versions, etc.) that put worktrees in `.claude/worktrees/`
+
+If we ever switch to **Approach A** (codev-managed sibling worktrees at `<parent>/<repo>-<branch>`), the detection path can be expanded to recognize **both** patterns simultaneously — the nested pattern is independent of how new worktrees are created. So switching launch strategy doesn't break detection of pre-existing nested worktrees.
+
+### Future-proofing: when Ghostty exposes per-tab TTY
+
+The `-n` flag (and the title-match layer) is currently the only way to disambiguate Ghostty tabs that share a cwd. Once Ghostty's AppleScript surface exposes per-tab TTY ([ghostty-org/ghostty#11354](https://github.com/ghostty-org/ghostty/pull/11354), merged but unreleased as of v1.0.75), Ghostty switching can use TTY match the same way iTerm2 / Terminal.app / cmux do. At that point:
+
+- The `-n` flag becomes optional — tab disambiguation no longer relies on title
+- Codev should add a Ghostty TTY-match layer (parallel to existing iTerm2 / Terminal.app code)
+- Existing `-n`-set sessions keep working (title match still functions as a Layer 1 fast path)
+
 ## Technical Decisions
 
 ### TypeScript vs Rust

--- a/docs/claude-session-integration-design.md
+++ b/docs/claude-session-integration-design.md
@@ -552,10 +552,12 @@ Two approaches were considered:
 
 | Approach | Description | Trade-off |
 |---|---|---|
-| **A. `git worktree add`** (codev manages) | Create worktree at sibling path (`<parent>/<repo>-<branch>`), launch terminal there. claude-control uses this. | Full control, sibling visibility, no auto-cleanup surprise. But we own all lifecycle (cleanup UI, branch conflicts, error handling). |
-| **B. `claude -w <name> -n <name>`** (chosen) | Let Claude CLI create+manage the worktree. Pass `-n` to set a custom title. | Minimal code, leverages Claude CLI features (auto-cleanup, tmux). Relies on `-n` setting tab title for Ghostty switch. |
+| **A. `git worktree add`** (codev manages) | Create worktree at sibling path (`<parent>/<repo>-<branch>`), launch terminal there. claude-control uses this. | Full control, sibling visibility, **no IDE/git-GUI clutter inside the parent repo**. But we own all lifecycle (cleanup UI, branch conflicts, error handling). |
+| **B. `claude -w <name> -n <name>`** (chosen) | Let Claude CLI create+manage the worktree. Pass `-n` to set a custom title. | Minimal code, leverages Claude CLI features (auto-cleanup, tmux). **Downside: nested worktree folder visible to VS Code / git GUI** — users may see worktree files in their workspace, accidentally commit them, or include them in cross-repo searches. Mitigation: `.gitignore` `.claude/worktrees/`. |
 
 We chose **B** because codev is Claude-Code-focused (claude-control is multi-tool, so they need their own implementation). Claude CLI's worktree lifecycle (auto-cleanup if clean) is the right default for codev users.
+
+**A and B are not mutually exclusive.** A future iteration could add a setting to choose between them, or fall back to A for users who hit B's limitations (e.g., the IDE-clutter concern).
 
 ### The `-n` flag and Ghostty switch
 
@@ -566,6 +568,8 @@ We chose **B** because codev is Claude-Code-focused (claude-control is multi-too
 - Ghostty's AppleScript `working directory of term` reports the shell's cwd → both terminals report the same cwd → AppleScript "first match wins" focuses the wrong tab.
 
 Fix: pass `-n <name>` so Claude CLI sets a custom title. Codev's existing AppleScript title-match (Layer 1) finds the correct tab regardless of cwd. Other terminals (iTerm2 / Terminal.app / cmux) use TTY match and were already unaffected.
+
+**Future:** once Ghostty exposes per-tab TTY ([ghostty-org/ghostty#11354](https://github.com/ghostty-org/ghostty/pull/11354), merged but not released yet), Ghostty switch can use TTY match like the other terminals. The `-n` flag and the title-match layer become optional at that point — we can drop them or keep them as defense-in-depth.
 
 ### AppleScript `activate` timing
 

--- a/docs/claude-session-integration-design.md
+++ b/docs/claude-session-integration-design.md
@@ -542,6 +542,57 @@ Ghostty has full AppleScript support via `Ghostty.sdef`:
 - Custom terminal command template
 - Per-terminal PID/TTY matching (pending upstream: Ghostty #11592, cmux #1826)
 
+## Git Worktree Sessions
+
+Claude Code's `claude -w <name>` creates a git worktree at `<repo>/.claude/worktrees/<name>` and starts a session inside it. CodeV exposes this from the Projects tab via `⌘+Shift+Enter`.
+
+### Why we leverage `claude -w` instead of `git worktree add` ourselves
+
+Two approaches were considered:
+
+| Approach | Description | Trade-off |
+|---|---|---|
+| **A. `git worktree add`** (codev manages) | Create worktree at sibling path (`<parent>/<repo>-<branch>`), launch terminal there. claude-control uses this. | Full control, sibling visibility, no auto-cleanup surprise. But we own all lifecycle (cleanup UI, branch conflicts, error handling). |
+| **B. `claude -w <name> -n <name>`** (chosen) | Let Claude CLI create+manage the worktree. Pass `-n` to set a custom title. | Minimal code, leverages Claude CLI features (auto-cleanup, tmux). Relies on `-n` setting tab title for Ghostty switch. |
+
+We chose **B** because codev is Claude-Code-focused (claude-control is multi-tool, so they need their own implementation). Claude CLI's worktree lifecycle (auto-cleanup if clean) is the right default for codev users.
+
+### The `-n` flag and Ghostty switch
+
+`claude -w <name>` alone breaks Ghostty session switching:
+
+- **Worktree terminal cwd = parent repo** (because we `cd <parent> && claude -w <name>`; the shell stays in parent, only the claude process internally cd's into the worktree).
+- **Main session terminal cwd = parent repo** too.
+- Ghostty's AppleScript `working directory of term` reports the shell's cwd → both terminals report the same cwd → AppleScript "first match wins" focuses the wrong tab.
+
+Fix: pass `-n <name>` so Claude CLI sets a custom title. Codev's existing AppleScript title-match (Layer 1) finds the correct tab regardless of cwd. Other terminals (iTerm2 / Terminal.app / cmux) use TTY match and were already unaffected.
+
+### AppleScript `activate` timing
+
+Old behavior:
+```applescript
+tell application "Ghostty"
+  activate                  -- always brings Ghostty front
+  ... match logic ...
+  return "not found"
+end tell
+```
+
+When match failed, `activate` had already run, so Ghostty would surface its last-active window — looking like "switched to the wrong tab". Fixed by moving `activate` inside each match success branch.
+
+### Worktree session display
+
+`parseWorktreePath()` recognizes `<repo>/.claude/worktrees/<name>` paths and exposes:
+- `projectName` = parent repo name (e.g., `codev` instead of `test-worktree-4`)
+- `isWorktree` = true → renders a `WT` badge in the Sessions list
+- `parentRepo` = parent repo path (kept for grouping/display logic)
+
+The `project` field still holds the original worktree path so resume / cwd matching continue to work.
+
+### Resume after Claude CLI auto-cleanup
+
+When a `-w` session exits without uncommitted changes, Claude CLI may remove the worktree directory. The session JSONL is stored at `~/.claude/projects/<encoded>/<uuid>.jsonl` (independent of the worktree directory) so `claude --resume <uuid>` still works — the cwd shown in the session header just reflects wherever resume was invoked from. No special handling needed in codev.
+
 ## Technical Decisions
 
 ### TypeScript vs Rust

--- a/docs/claude-session-integration-design.md
+++ b/docs/claude-session-integration-design.md
@@ -571,6 +571,10 @@ Fix: pass `-n <name>` so Claude CLI sets a custom title. Codev's existing AppleS
 
 **Future:** once Ghostty exposes per-tab TTY ([ghostty-org/ghostty#11354](https://github.com/ghostty-org/ghostty/pull/11354), merged but not released yet), Ghostty switch can use TTY match like the other terminals. The `-n` flag and the title-match layer become optional at that point — we can drop them or keep them as defense-in-depth.
 
+### AppleScript switch latency
+
+The Ghostty / Terminal.app / iTerm2 switch scripts iterate `windows × tabs × terminals` to find a match. Latency therefore scales with the user's open terminal count. With many windows/tabs (10+ Ghostty tabs, 50+ Terminal.app tabs) `osascript` invocation can be perceptibly slow (hundreds of ms). This is independent of worktree code — it predates this PR. Mitigations to investigate later: cache window IDs by sessionId, short-circuit on first match, or use TTY/PID directly once Ghostty exposes them.
+
 ### AppleScript `activate` timing
 
 Old behavior:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "CodeV",
   "productName": "CodeV",
-  "version": "1.0.74",
+  "version": "1.0.75",
   "description": "Quick switcher for VS Code, Cursor, and Claude Code sessions",
   "repository": {
     "type": "git",

--- a/src/claude-session-utility.ts
+++ b/src/claude-session-utility.ts
@@ -41,6 +41,29 @@ export const parseWorktreePath = (
 };
 
 /**
+ * Validate a worktree name before passing it into the launch shell command.
+ * Whitelist: alphanumerics + a few branch-name-safe punctuation chars.
+ * Rejects shell metacharacters ($ ` " ' \ ; | & space etc.) so the name
+ * cannot break out of the quoted argument in `claude -w "<name>" -n "<name>"`.
+ *
+ * Conservative subset of git's branch name rules:
+ * - allows: a-z A-Z 0-9 / - _ . +
+ * - disallows: leading/trailing dot, leading dash, double slash,
+ *   leading/trailing slash, anything else.
+ */
+export const isValidWorktreeName = (name: string): boolean => {
+  if (!name) return false;
+  if (name.length > 100) return false;
+  if (!/^[A-Za-z0-9_./+-]+$/.test(name)) return false;
+  if (name.startsWith('-') || name.startsWith('.')) return false;
+  if (name.startsWith('/') || name.endsWith('/')) return false;
+  if (name.endsWith('.')) return false;
+  if (name.includes('//')) return false;
+  if (name.includes('..')) return false;
+  return true;
+};
+
+/**
  * Compute the display project name. For worktree paths, returns parent repo name.
  */
 export const getProjectDisplayName = (projectPath: string): string => {
@@ -1389,6 +1412,16 @@ export const launchNewClaudeSession = (
   // For worktree sessions: also pass -n so claude sets a custom title
   // (matches the worktree name). This lets AppleScript title-match find the
   // correct terminal tab in Ghostty (which lacks per-tab TTY exposure).
+  // Validate worktreeName to prevent shell injection — it's interpolated
+  // into a string that ends up in `do script "..."` AppleScript and an
+  // interactive shell command.
+  if (worktreeName && !isValidWorktreeName(worktreeName)) {
+    console.error(
+      '[launchNewClaudeSession] rejected invalid worktreeName:',
+      JSON.stringify(worktreeName),
+    );
+    return;
+  }
   const shortCmd = worktreeName
     ? `claude -w "${worktreeName}" -n "${worktreeName}"`
     : 'claude';

--- a/src/claude-session-utility.ts
+++ b/src/claude-session-utility.ts
@@ -11,8 +11,8 @@ import { getCurrentIDEBundleId } from './vscode-based-ide-utility';
 
 export interface ClaudeSession {
   sessionId: string;
-  project: string;         // full path, e.g. /Users/grimmer/git/fred-ff
-  projectName: string;     // folder name, e.g. fred-ff
+  project: string;         // full path, e.g. /Users/grimmer/git/fred-ff or <repo>/.claude/worktrees/<name>
+  projectName: string;     // display name: parent repo name if worktree, else folder name
   firstUserMessage: string;
   lastUserMessage: string;
   lastAssistantMessage?: string; // only loaded for active sessions
@@ -22,7 +22,32 @@ export interface ClaudeSession {
   activePid?: number;
   terminalApp?: string;    // detected terminal: 'iterm2', 'cmux', 'ghostty', 'vscode', etc.
   entrypoint?: string;     // 'cli', 'claude-vscode', etc.
+  isWorktree?: boolean;    // true if project path is <repo>/.claude/worktrees/<name>
+  parentRepo?: string;     // for worktree sessions: the parent repo path
 }
+
+/**
+ * Parse a Claude Code worktree path into parent repo + worktree name.
+ * Returns null if the path is not a worktree path.
+ * E.g. /Users/me/git/codev/.claude/worktrees/fix-bug
+ *   → { parentRepo: '/Users/me/git/codev', worktreeName: 'fix-bug' }
+ */
+export const parseWorktreePath = (
+  p: string,
+): { parentRepo: string; worktreeName: string } | null => {
+  if (!p) return null;
+  const match = p.match(/^(.+)\/\.claude\/worktrees\/([^/]+)\/?$/);
+  return match ? { parentRepo: match[1], worktreeName: match[2] } : null;
+};
+
+/**
+ * Compute the display project name. For worktree paths, returns parent repo name.
+ */
+export const getProjectDisplayName = (projectPath: string): string => {
+  const worktree = parseWorktreePath(projectPath);
+  const displayPath = worktree ? worktree.parentRepo : projectPath;
+  return path.basename(displayPath) || displayPath;
+};
 
 export interface ActiveSessionResult {
   activeMap: Map<string, number>;      // sessionId -> pid (all active sessions)
@@ -133,16 +158,22 @@ export const readClaudeSessions = (limit = 100): ClaudeSession[] => {
 
     const allSessions = Array.from(bySession.values())
       .sort((a, b) => b.lastTimestamp - a.lastTimestamp)
-      .map((s) => ({
-        sessionId: s.sessionId,
-        project: s.project,
-        projectName: path.basename(s.project) || s.project,
-        firstUserMessage: s.firstDisplay,
-        lastUserMessage: s.lastDisplay,
-        lastTimestamp: s.lastTimestamp,
-        messageCount: s.promptCount,
-        isActive: false,
-      }));
+      .map((s) => {
+        const worktree = parseWorktreePath(s.project);
+        return {
+          sessionId: s.sessionId,
+          project: s.project,
+          projectName: worktree
+            ? path.basename(worktree.parentRepo) || worktree.parentRepo
+            : (path.basename(s.project) || s.project),
+          firstUserMessage: s.firstDisplay,
+          lastUserMessage: s.lastDisplay,
+          lastTimestamp: s.lastTimestamp,
+          messageCount: s.promptCount,
+          isActive: false,
+          ...(worktree && { isWorktree: true, parentRepo: worktree.parentRepo }),
+        };
+      });
 
     cachedSessions = allSessions;
     cacheTimestamp = now;
@@ -825,10 +856,13 @@ export const scanClosedVSCodeSessions = async (
     );
     // Use actual cwd from JSONL content, fall back to hooks index cwd
     const actualCwd = info.cwd || cwd;
+    const worktree = parseWorktreePath(actualCwd);
     sessions.push({
       sessionId,
       project: actualCwd,
-      projectName: path.basename(actualCwd) || actualCwd,
+      projectName: worktree
+        ? path.basename(worktree.parentRepo) || worktree.parentRepo
+        : (path.basename(actualCwd) || actualCwd),
       firstUserMessage: info.firstUserMessage,
       lastUserMessage: info.lastUserMessage,
       lastAssistantMessage: info.lastAssistantMessage,
@@ -836,6 +870,7 @@ export const scanClosedVSCodeSessions = async (
       messageCount: info.messageCount,
       isActive: false,
       entrypoint: 'claude-vscode',
+      ...(worktree && { isWorktree: true, parentRepo: worktree.parentRepo }),
     });
   });
 
@@ -903,12 +938,16 @@ export const detectActiveSessions = async (): Promise<ActiveSessionResult> => {
             activeMap.set(sessionId, pid);
             // Queue async JSONL read (head/tail in parallel)
             const startedAt = data.startedAt;
+            const activeWorktree = parseWorktreePath(cwd);
             vscodeReadPromises.push(
               readVSCodeSessionFromJSONL(sessionId, cwd, execPromise).then((info) => {
                 vscodeSessions.push({
                   sessionId,
                   project: cwd,
-                  projectName: path.basename(cwd) || cwd,
+                  projectName: activeWorktree
+                    ? path.basename(activeWorktree.parentRepo) || activeWorktree.parentRepo
+                    : (path.basename(cwd) || cwd),
+                  ...(activeWorktree && { isWorktree: true, parentRepo: activeWorktree.parentRepo }),
                   firstUserMessage: info.firstUserMessage,
                   lastUserMessage: info.lastUserMessage,
                   lastAssistantMessage: info.lastAssistantMessage,
@@ -1166,14 +1205,16 @@ export const runCommandInTerminal = (
   switch (terminalApp) {
     case 'ghostty': {
       const tmpScript = '/tmp/codev-ghostty-launch.scpt';
+      // Escape double quotes in claudeCmd for AppleScript string embedding
+      const escapedCmd = claudeCmd.replace(/"/g, '\\"');
       const launchScript = terminalMode === 'window'
         ? `tell application "Ghostty"
-  set cfg to new surface configuration from {initial working directory:"${projectPath}", initial input:"${claudeCmd}\\n"}
+  set cfg to new surface configuration from {initial working directory:"${projectPath}", initial input:"${escapedCmd}\\n"}
   new window with configuration cfg
   activate
 end tell`
         : `tell application "Ghostty"
-  set cfg to new surface configuration from {initial working directory:"${projectPath}", initial input:"${claudeCmd}\\n"}
+  set cfg to new surface configuration from {initial working directory:"${projectPath}", initial input:"${escapedCmd}\\n"}
   if (count windows) > 0 then
     activate
     new tab in front window with configuration cfg
@@ -1317,6 +1358,7 @@ export const launchNewClaudeSession = (
   projectPath: string,
   terminalApp: string = 'iterm2',
   terminalMode: string = 'tab',
+  worktreeName?: string,
 ): void => {
   if (terminalApp === 'vscode') {
     const { execFile } = require('child_process');
@@ -1344,7 +1386,14 @@ export const launchNewClaudeSession = (
     }
     return;
   }
-  runCommandInTerminal(`cd "${projectPath}" && claude`, 'claude', projectPath, terminalApp, terminalMode);
+  // For worktree sessions: also pass -n so claude sets a custom title
+  // (matches the worktree name). This lets AppleScript title-match find the
+  // correct terminal tab in Ghostty (which lacks per-tab TTY exposure).
+  const shortCmd = worktreeName
+    ? `claude -w "${worktreeName}" -n "${worktreeName}"`
+    : 'claude';
+  const fullCmd = `cd "${projectPath}" && ${shortCmd}`;
+  runCommandInTerminal(fullCmd, shortCmd, projectPath, terminalApp, terminalMode);
 };
 
 /**
@@ -1698,7 +1747,9 @@ export const openSessionInGhostty = (
   const { exec } = require('child_process');
 
   if (isActive) {
-    // Two-layer matching: title first (precise), then cwd fallback
+    // Two-layer matching: title first (precise), then cwd fallback.
+    // IMPORTANT: only `activate` after a match is found — otherwise Ghostty
+    // jumps to the last-active window (visually "wrong window") on miss.
     const titleMatch = customTitle
       ? `
   -- Layer 1: title matching
@@ -1706,6 +1757,7 @@ export const openSessionInGhostty = (
     repeat with t in tabs of w
       repeat with term in terminals of t
         if name of term contains "${customTitle.replace(/"/g, '\\"')}" then
+          activate
           focus term
           return "found-by-title"
         end if
@@ -1716,13 +1768,13 @@ export const openSessionInGhostty = (
 
     const tmpScript = '/tmp/codev-ghostty-switch.scpt';
     const switchScript = `tell application "Ghostty"
-  activate
   ${titleMatch}
   -- Layer 2: cwd matching (fallback)
   repeat with w in windows
     repeat with t in tabs of w
       repeat with term in terminals of t
         if working directory of term is "${projectPath}" then
+          activate
           focus term
           return "found-by-cwd"
         end if

--- a/src/electron-api.d.ts
+++ b/src/electron-api.d.ts
@@ -68,6 +68,7 @@ interface IElectronAPI {
   refreshSessionPreview: (sessions: any[]) => Promise<Record<string, { lastUserMessage: string; lastAssistantMessage: string }>>;
   openClaudeSession: (sessionId: string, projectPath: string, isActive: boolean, activePid?: number, customTitle?: string) => void;
   launchNewClaudeSession: (projectPath: string) => void;
+  launchNewClaudeSessionWorktree: (projectPath: string, worktreeName: string) => void;
   launchNewClaudeSessionInCodev: (projectPath: string) => void;
   copyClaudeSessionCommand: (sessionId: string, projectPath: string) => void;
   loadSessionEnrichment: (sessions: any[]) => Promise<{ titles: Record<string, string>; branches: Record<string, string>; prLinks: Record<string, { prNumber: number; prUrl: string }> }>;

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,6 +30,7 @@ import {
   setLaunchInCodevTerminalCallback,
   launchNewClaudeSession,
   scanClosedVSCodeSessions,
+  isValidWorktreeName,
 } from './claude-session-utility';
 import {
   installHooks,
@@ -2152,6 +2153,11 @@ ipcMain.on('launch-new-claude-session', async (_event, projectPath: string) => {
 ipcMain.on('launch-new-claude-session-worktree', async (_event, projectPath: string, worktreeName: string) => {
   if (!existsSync(projectPath)) {
     console.log('[launch-new-claude-session-worktree] path does not exist:', projectPath);
+    return;
+  }
+  // Validate at IPC boundary (defense in depth) — the renderer also validates.
+  if (!isValidWorktreeName(worktreeName)) {
+    console.error('[launch-new-claude-session-worktree] invalid worktreeName:', JSON.stringify(worktreeName));
     return;
   }
   const terminalApp = ((await settings.get('session-terminal-app')) || 'iterm2') as string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -2149,6 +2149,16 @@ ipcMain.on('launch-new-claude-session', async (_event, projectPath: string) => {
   launchNewClaudeSession(projectPath, terminalApp, terminalMode);
 });
 
+ipcMain.on('launch-new-claude-session-worktree', async (_event, projectPath: string, worktreeName: string) => {
+  if (!existsSync(projectPath)) {
+    console.log('[launch-new-claude-session-worktree] path does not exist:', projectPath);
+    return;
+  }
+  const terminalApp = ((await settings.get('session-terminal-app')) || 'iterm2') as string;
+  const terminalMode = ((await settings.get('session-terminal-mode')) || 'tab') as string;
+  launchNewClaudeSession(projectPath, terminalApp, terminalMode, worktreeName);
+});
+
 ipcMain.on('launch-new-claude-session-in-codev', (_event, projectPath: string) => {
   if (!existsSync(projectPath)) {
     console.log('[launch-new-claude-session-in-codev] path does not exist:', projectPath);

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -65,6 +65,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.send('open-claude-session', sessionId, projectPath, isActive, activePid, customTitle),
   launchNewClaudeSession: (projectPath: string) =>
     ipcRenderer.send('launch-new-claude-session', projectPath),
+  launchNewClaudeSessionWorktree: (projectPath: string, worktreeName: string) =>
+    ipcRenderer.send('launch-new-claude-session-worktree', projectPath, worktreeName),
   launchNewClaudeSessionInCodev: (projectPath: string) =>
     ipcRenderer.send('launch-new-claude-session-in-codev', projectPath),
   copyClaudeSessionCommand: (sessionId: string, projectPath: string) =>

--- a/src/switcher-ui.tsx
+++ b/src/switcher-ui.tsx
@@ -269,7 +269,7 @@ const formatRelativeTime = (timestamp: string): string => {
 let loadTimes = 0;
 function SwitcherApp() {
   const optionPress = useRef(false);
-  const launchClaudeRef = useRef<'external' | 'codev' | null>(null);
+  const launchClaudeRef = useRef<'external' | 'codev' | 'worktree' | null>(null);
 
   const ref = useRef(null);
   const sessionSearchRef = useRef<HTMLInputElement>(null);
@@ -312,6 +312,9 @@ function SwitcherApp() {
   const [terminalApps, setTerminalApps] = useState<Record<string, string>>({});
   const [sessionStatuses, setSessionStatuses] = useState<Record<string, string>>({});
   const modeRef = useRef<SwitcherMode>(initialMode);
+  const [worktreeDialog, setWorktreeDialog] = useState<{ projectPath: string; projectName: string } | null>(null);
+  const [worktreeBranch, setWorktreeBranch] = useState('');
+  const worktreeInputRef = useRef<HTMLInputElement>(null);
   const activeStateRef = useRef<Record<string, number>>({});
   const allSessionsRef = useRef<any[]>([]);
   const lastAssistantFetchRef = useRef<Record<string, number>>({});
@@ -1239,6 +1242,25 @@ function SwitcherApp() {
                             }}
                           />
                         </span>
+                        {session.isWorktree && (
+                          <span
+                            title="Git worktree session"
+                            style={{
+                              marginLeft: '6px',
+                              fontSize: '9px',
+                              color: '#c4b5fd',
+                              border: '1px solid #7c6bb5',
+                              borderRadius: '3px',
+                              padding: '1px 4px',
+                              textTransform: 'uppercase',
+                              backgroundColor: 'rgba(124, 107, 181, 0.12)',
+                              letterSpacing: '0.5px',
+                              fontWeight: '600',
+                            }}
+                          >
+                            WT
+                          </span>
+                        )}
                         {customTitles[session.sessionId] && (
                           <span style={{ color: '#7ec87e', fontSize: '13px', fontWeight: '500' }}>
                             {' '}* <Highlighter
@@ -1460,10 +1482,13 @@ function SwitcherApp() {
             }
           }
           // Cmd+Enter or Shift+Enter: launch new Claude session
+          // Cmd+Shift+Enter: open worktree dialog
           // Set flag so onChange knows to launch instead of opening IDE
           // Clear on every keypress to prevent stale ref if onChange didn't fire
           launchClaudeRef.current = null;
-          if (evt.key === 'Enter' && (evt.metaKey || evt.shiftKey)) {
+          if (evt.key === 'Enter' && evt.metaKey && evt.shiftKey) {
+            launchClaudeRef.current = 'worktree';
+          } else if (evt.key === 'Enter' && (evt.metaKey || evt.shiftKey)) {
             launchClaudeRef.current = evt.shiftKey ? 'codev' : 'external';
           }
         }}
@@ -1473,7 +1498,12 @@ function SwitcherApp() {
         onChange={(evt: any) => {
           const launchMode = launchClaudeRef.current;
           launchClaudeRef.current = null;
-          if (launchMode === 'codev') {
+          if (launchMode === 'worktree') {
+            const name = evt.value?.split('/').pop() || evt.value;
+            setWorktreeDialog({ projectPath: evt.value, projectName: name });
+            setWorktreeBranch('');
+            setTimeout(() => worktreeInputRef.current?.focus(), 0);
+          } else if (launchMode === 'codev') {
             window.electronAPI.launchNewClaudeSessionInCodev(evt.value);
           } else if (launchMode === 'external') {
             window.electronAPI.launchNewClaudeSession(evt.value);
@@ -1489,7 +1519,7 @@ function SwitcherApp() {
         components={{
           DropdownIndicator: () => (
             <div style={{ fontSize: '11px', color: '#666', paddingRight: '8px', whiteSpace: 'nowrap' }}>
-              {'\u2318+Enter: New Claude'}
+              {'\u2318+Shift+Enter: Worktree  \u2318+Enter: New Claude'}
             </div>
           ),
           Option: (props) => OptionUI(props, onDeleteClick, (path: string) => {
@@ -1649,6 +1679,122 @@ function SwitcherApp() {
       />
       </div>
       ))}
+      {/* Worktree launch dialog */}
+      {worktreeDialog && (
+        <div
+          style={{
+            position: 'fixed',
+            top: 0, left: 0, right: 0, bottom: 0,
+            backgroundColor: 'rgba(0, 0, 0, 0.5)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 1000,
+          }}
+          onClick={(e) => { if (e.target === e.currentTarget) setWorktreeDialog(null); }}
+        >
+          <div style={{
+            backgroundColor: '#2a2a2a',
+            borderRadius: '8px',
+            padding: '20px',
+            width: '400px',
+            border: '1px solid #444',
+            boxShadow: '0 8px 32px rgba(0, 0, 0, 0.5)',
+          }}>
+            <div style={{ fontSize: '15px', fontWeight: '600', color: '#eee', marginBottom: '4px' }}>
+              New Claude Session
+            </div>
+            <div style={{ fontSize: '12px', color: '#888', marginBottom: '16px' }}>
+              {worktreeDialog.projectName}
+            </div>
+
+            <div style={{ fontSize: '12px', color: '#aaa', marginBottom: '6px' }}>
+              Branch name <span style={{ color: '#666' }}>(optional — creates a worktree)</span>
+            </div>
+            <input
+              ref={worktreeInputRef}
+              type="text"
+              value={worktreeBranch}
+              onChange={(e) => setWorktreeBranch(e.target.value)}
+              placeholder="e.g. fix/login-bug"
+              onKeyDown={(e) => {
+                if (e.key === 'Escape') {
+                  setWorktreeDialog(null);
+                } else if (e.key === 'Enter') {
+                  e.preventDefault();
+                  if (worktreeBranch.trim()) {
+                    window.electronAPI.launchNewClaudeSessionWorktree(
+                      worktreeDialog.projectPath,
+                      worktreeBranch.trim(),
+                    );
+                  } else {
+                    window.electronAPI.launchNewClaudeSession(worktreeDialog.projectPath);
+                  }
+                  setWorktreeDialog(null);
+                }
+              }}
+              style={{
+                width: '100%',
+                padding: '8px 10px',
+                backgroundColor: '#3c3c3c',
+                border: '1px solid #555',
+                borderRadius: '4px',
+                color: '#eee',
+                fontSize: '13px',
+                outline: 'none',
+                boxSizing: 'border-box',
+              }}
+              onFocus={(e) => { e.currentTarget.style.borderColor = '#00BCD4'; }}
+              onBlur={(e) => { e.currentTarget.style.borderColor = '#555'; }}
+            />
+            <div style={{ fontSize: '11px', color: '#666', marginTop: '4px', marginBottom: '16px' }}>
+              Leave empty for a normal session (no worktree)
+            </div>
+
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px' }}>
+              <button
+                onClick={() => setWorktreeDialog(null)}
+                style={{
+                  padding: '6px 16px',
+                  backgroundColor: 'transparent',
+                  border: '1px solid #555',
+                  borderRadius: '4px',
+                  color: '#aaa',
+                  fontSize: '12px',
+                  cursor: 'pointer',
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => {
+                  if (worktreeBranch.trim()) {
+                    window.electronAPI.launchNewClaudeSessionWorktree(
+                      worktreeDialog.projectPath,
+                      worktreeBranch.trim(),
+                    );
+                  } else {
+                    window.electronAPI.launchNewClaudeSession(worktreeDialog.projectPath);
+                  }
+                  setWorktreeDialog(null);
+                }}
+                style={{
+                  padding: '6px 16px',
+                  backgroundColor: THEME.primary,
+                  border: 'none',
+                  borderRadius: '4px',
+                  color: '#fff',
+                  fontSize: '12px',
+                  cursor: 'pointer',
+                  fontWeight: '500',
+                }}
+              >
+                Launch
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/switcher-ui.tsx
+++ b/src/switcher-ui.tsx
@@ -168,6 +168,23 @@ const acceleratorToSymbols = (acc: string): string =>
     .replace(/Shift/g, '⇧')
     .replace(/\+/g, '');
 
+/**
+ * Validate worktree name (mirrors src/claude-session-utility.ts isValidWorktreeName).
+ * Whitelist of branch-name-safe chars; rejects shell metacharacters so the name
+ * cannot break out of the quoted shell argument in `claude -w "<name>" -n "<name>"`.
+ */
+const isValidWorktreeName = (name: string): boolean => {
+  if (!name) return false;
+  if (name.length > 100) return false;
+  if (!/^[A-Za-z0-9_./+-]+$/.test(name)) return false;
+  if (name.startsWith('-') || name.startsWith('.')) return false;
+  if (name.startsWith('/') || name.endsWith('/')) return false;
+  if (name.endsWith('.')) return false;
+  if (name.includes('//')) return false;
+  if (name.includes('..')) return false;
+  return true;
+};
+
 let _homeDir = '';
 let _homePrefix = '';
 // Fetch home dir async on load, cache for sync access
@@ -1519,7 +1536,7 @@ function SwitcherApp() {
         components={{
           DropdownIndicator: () => (
             <div style={{ fontSize: '11px', color: '#666', paddingRight: '8px', whiteSpace: 'nowrap' }}>
-              {'\u2318+Shift+Enter: Worktree  \u2318+Enter: New Claude'}
+              {'\u2318+Shift+Enter: Worktree  \u2318+Enter: External  Shift+Enter: Codev'}
             </div>
           ),
           Option: (props) => OptionUI(props, onDeleteClick, (path: string) => {
@@ -1680,121 +1697,133 @@ function SwitcherApp() {
       </div>
       ))}
       {/* Worktree launch dialog */}
-      {worktreeDialog && (
-        <div
-          style={{
-            position: 'fixed',
-            top: 0, left: 0, right: 0, bottom: 0,
-            backgroundColor: 'rgba(0, 0, 0, 0.5)',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            zIndex: 1000,
-          }}
-          onClick={(e) => { if (e.target === e.currentTarget) setWorktreeDialog(null); }}
-        >
-          <div style={{
-            backgroundColor: '#2a2a2a',
-            borderRadius: '8px',
-            padding: '20px',
-            width: '400px',
-            border: '1px solid #444',
-            boxShadow: '0 8px 32px rgba(0, 0, 0, 0.5)',
-          }}>
-            <div style={{ fontSize: '15px', fontWeight: '600', color: '#eee', marginBottom: '4px' }}>
-              New Claude Session
-            </div>
-            <div style={{ fontSize: '12px', color: '#888', marginBottom: '16px' }}>
-              {worktreeDialog.projectName}
-            </div>
-
-            <div style={{ fontSize: '12px', color: '#aaa', marginBottom: '6px' }}>
-              Branch name <span style={{ color: '#666' }}>(optional — creates a worktree)</span>
-            </div>
-            <input
-              ref={worktreeInputRef}
-              type="text"
-              value={worktreeBranch}
-              onChange={(e) => setWorktreeBranch(e.target.value)}
-              placeholder="e.g. fix/login-bug"
-              onKeyDown={(e) => {
-                if (e.key === 'Escape') {
-                  setWorktreeDialog(null);
-                } else if (e.key === 'Enter') {
-                  e.preventDefault();
-                  if (worktreeBranch.trim()) {
-                    window.electronAPI.launchNewClaudeSessionWorktree(
-                      worktreeDialog.projectPath,
-                      worktreeBranch.trim(),
-                    );
-                  } else {
-                    window.electronAPI.launchNewClaudeSession(worktreeDialog.projectPath);
-                  }
-                  setWorktreeDialog(null);
-                }
-              }}
+      {worktreeDialog && (() => {
+        const trimmed = worktreeBranch.trim();
+        const nameInvalid = trimmed.length > 0 && !isValidWorktreeName(trimmed);
+        const submit = () => {
+          if (trimmed) {
+            if (!isValidWorktreeName(trimmed)) return; // guard against bypass
+            window.electronAPI.launchNewClaudeSessionWorktree(
+              worktreeDialog.projectPath,
+              trimmed,
+            );
+          } else {
+            window.electronAPI.launchNewClaudeSession(worktreeDialog.projectPath);
+          }
+          setWorktreeDialog(null);
+        };
+        return (
+          <div
+            style={{
+              position: 'fixed',
+              top: 0, left: 0, right: 0, bottom: 0,
+              backgroundColor: 'rgba(0, 0, 0, 0.5)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              zIndex: 1000,
+            }}
+            // Click on backdrop closes; clicks inside the inner card don't reach here
+            onClick={() => setWorktreeDialog(null)}
+            // Stop document-level keydown handlers (Tab, arrows, etc.) from
+            // firing app-level shortcuts while the modal has focus
+            onKeyDown={(e) => e.stopPropagation()}
+          >
+            <div
+              role="dialog"
+              aria-modal="true"
+              aria-label="New Claude session — optional worktree"
+              onClick={(e) => e.stopPropagation()}
               style={{
-                width: '100%',
-                padding: '8px 10px',
-                backgroundColor: '#3c3c3c',
-                border: '1px solid #555',
-                borderRadius: '4px',
-                color: '#eee',
-                fontSize: '13px',
-                outline: 'none',
-                boxSizing: 'border-box',
+                backgroundColor: '#2a2a2a',
+                borderRadius: '8px',
+                padding: '20px',
+                width: '400px',
+                border: '1px solid #444',
+                boxShadow: '0 8px 32px rgba(0, 0, 0, 0.5)',
               }}
-              onFocus={(e) => { e.currentTarget.style.borderColor = '#00BCD4'; }}
-              onBlur={(e) => { e.currentTarget.style.borderColor = '#555'; }}
-            />
-            <div style={{ fontSize: '11px', color: '#666', marginTop: '4px', marginBottom: '16px' }}>
-              Leave empty for a normal session (no worktree)
-            </div>
+            >
+              <div style={{ fontSize: '15px', fontWeight: '600', color: '#eee', marginBottom: '4px' }}>
+                New Claude Session
+              </div>
+              <div style={{ fontSize: '12px', color: '#888', marginBottom: '16px' }}>
+                {worktreeDialog.projectName}
+              </div>
 
-            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px' }}>
-              <button
-                onClick={() => setWorktreeDialog(null)}
-                style={{
-                  padding: '6px 16px',
-                  backgroundColor: 'transparent',
-                  border: '1px solid #555',
-                  borderRadius: '4px',
-                  color: '#aaa',
-                  fontSize: '12px',
-                  cursor: 'pointer',
-                }}
-              >
-                Cancel
-              </button>
-              <button
-                onClick={() => {
-                  if (worktreeBranch.trim()) {
-                    window.electronAPI.launchNewClaudeSessionWorktree(
-                      worktreeDialog.projectPath,
-                      worktreeBranch.trim(),
-                    );
-                  } else {
-                    window.electronAPI.launchNewClaudeSession(worktreeDialog.projectPath);
+              <div style={{ fontSize: '12px', color: '#aaa', marginBottom: '6px' }}>
+                Branch name <span style={{ color: '#666' }}>(optional — creates a worktree)</span>
+              </div>
+              <input
+                ref={worktreeInputRef}
+                type="text"
+                value={worktreeBranch}
+                onChange={(e) => setWorktreeBranch(e.target.value)}
+                placeholder="e.g. fix/login-bug"
+                onKeyDown={(e) => {
+                  if (e.key === 'Escape') {
+                    e.preventDefault();
+                    setWorktreeDialog(null);
+                  } else if (e.key === 'Enter') {
+                    e.preventDefault();
+                    if (!nameInvalid) submit();
                   }
-                  setWorktreeDialog(null);
                 }}
                 style={{
-                  padding: '6px 16px',
-                  backgroundColor: THEME.primary,
-                  border: 'none',
+                  width: '100%',
+                  padding: '8px 10px',
+                  backgroundColor: '#3c3c3c',
+                  border: `1px solid ${nameInvalid ? '#e57373' : '#555'}`,
                   borderRadius: '4px',
-                  color: '#fff',
-                  fontSize: '12px',
-                  cursor: 'pointer',
-                  fontWeight: '500',
+                  color: '#eee',
+                  fontSize: '13px',
+                  outline: 'none',
+                  boxSizing: 'border-box',
                 }}
-              >
-                Launch
-              </button>
+                onFocus={(e) => { if (!nameInvalid) e.currentTarget.style.borderColor = '#00BCD4'; }}
+                onBlur={(e) => { e.currentTarget.style.borderColor = nameInvalid ? '#e57373' : '#555'; }}
+              />
+              <div style={{ fontSize: '11px', color: nameInvalid ? '#e57373' : '#666', marginTop: '4px', marginBottom: '16px' }}>
+                {nameInvalid
+                  ? 'Use only letters, digits, /, -, _, ., +. No leading dash/dot/slash.'
+                  : 'Leave empty for a normal session (no worktree)'}
+              </div>
+
+              <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px' }}>
+                <button
+                  onClick={() => setWorktreeDialog(null)}
+                  style={{
+                    padding: '6px 16px',
+                    backgroundColor: 'transparent',
+                    border: '1px solid #555',
+                    borderRadius: '4px',
+                    color: '#aaa',
+                    fontSize: '12px',
+                    cursor: 'pointer',
+                  }}
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={submit}
+                  disabled={nameInvalid}
+                  style={{
+                    padding: '6px 16px',
+                    backgroundColor: nameInvalid ? '#444' : THEME.primary,
+                    border: 'none',
+                    borderRadius: '4px',
+                    color: nameInvalid ? '#888' : '#fff',
+                    fontSize: '12px',
+                    cursor: nameInvalid ? 'not-allowed' : 'pointer',
+                    fontWeight: '500',
+                  }}
+                >
+                  Launch
+                </button>
+              </div>
             </div>
           </div>
-        </div>
-      )}
+        );
+      })()}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Add `⌘+Shift+Enter` on the Projects tab to launch a Claude Code session as a git worktree. Plus polish: worktree-aware naming.

## What's new

### Launch a worktree session — `⌘+Shift+Enter`

A small dialog asks for an optional branch name:

- **Empty** → behaves like `⌘+Enter` (normal session)
- **With a name** → runs `claude -w "<name>" -n "<name>"` in the configured terminal. Claude CLI creates a fresh worktree at `<repo>/.claude/worktrees/<name>` and starts the session inside it.

`Esc` cancels, click outside cancels, `Enter` launches. Modal traps Tab/click events so background shortcuts/inputs don't fire while the dialog is open.

### Worktree session display

Sessions whose path is `<repo>/.claude/worktrees/<name>` now display:
- The **parent repo name** (e.g., `codev`) — not the worktree folder name (e.g., `test-worktree-4`)
- A small purple **`WT`** badge

New `parseWorktreePath()` helper + `isWorktree` / `parentRepo` fields on `ClaudeSession`. The `project` field still points at the worktree path (resume / cwd matching unchanged). **Detection is path-based**: also recognizes worktree sessions launched manually via `claude -w` or by other tools.

### Why `-n <name>` is required

Without `-n`, Ghostty session switching breaks for worktree sessions:

- Worktree terminal cwd = parent repo (shell stays in parent; only the claude process internally cd's into the worktree)
- Main terminal cwd = parent repo too
- Ghostty has no per-tab TTY exposure → only cwd / title match available
- Same cwd → AppleScript first-match-wins → wrong tab

Passing `-n <name>` makes Claude CLI write a `custom-title` JSONL entry. Codev's existing Layer-1 title match finds the correct tab. iTerm2 / Terminal.app / cmux were already unaffected (they use TTY match).

**Future:** once Ghostty exposes per-tab TTY ([ghostty-org/ghostty#11354](https://github.com/ghostty-org/ghostty/pull/11354)), the `-n` flag becomes optional.

### Shell-injection guard

`worktreeName` is interpolated into a shell command that ends up in AppleScript. Validated at three layers (dialog input, IPC handler, `launchNewClaudeSession`) via `isValidWorktreeName()` — whitelist of branch-name-safe characters; rejects shell metacharacters, leading dash/dot/slash, double slash, `..`.

## Why we use `claude -w` instead of `git worktree add` ourselves

Two approaches were considered. We picked **B** but **A** remains a viable future direction.

| Approach | Worktree path | Worktree creation | Trade-off |
|---|---|---|---|
| **A. We own it (claude-control's choice)** | `<parent>/<repo>-<branch>` (sibling) | `git worktree add` ourselves | Full control, sibling visibility, **no IDE/git-GUI clutter inside the parent repo**. But codev owns lifecycle: cleanup UI, branch conflict handling, error paths. |
| **B. `claude -w <name> -n <name>` (this PR)** | `<repo>/.claude/worktrees/<name>` (nested) | Claude CLI does it | Minimal code, leverages Claude CLI features (auto-cleanup, `--tmux`). Downside: **the nested worktree folder is visible to VS Code / git GUI**, so users may see worktree files in their workspace, accidentally commit them, or include them in cross-repo searches. |

**Why B for now:** codev is Claude-Code-focused (claude-control supports multiple AI CLIs, so they need their own implementation). Auto-cleanup is the right default for codev's typical use case. **Detection of `<repo>/.claude/worktrees/` paths is path-based**, so even if we ever add A as an option, existing nested worktrees keep showing the `WT` badge.

See the design doc update for the full discussion.

## Files

- `src/switcher-ui.tsx` — new dialog component, `⌘+Shift+Enter` keybinding, WT badge, hint text, modal event isolation, name validation
- `src/claude-session-utility.ts` — `parseWorktreePath()`, `isValidWorktreeName()`, worktree fields in 3 session sources, `-n` in launch
- `src/main.ts`, `src/preload.ts`, `src/electron-api.d.ts` — new `launch-new-claude-session-worktree` IPC with validation
- `docs/claude-session-integration-design.md` — added "Git Worktree Sessions" section
- `README.md`, `CHANGELOG.md`, `package.json` — feature doc + version 1.0.75

## Test plan

- [x] `⌘+Shift+Enter` opens dialog
- [x] Empty branch name → normal session (same as `⌘+Enter`)
- [x] With branch name → `claude -w … -n …` launches in external terminal
- [x] `Esc` / click-outside cancel
- [x] Worktree session shows parent repo name + WT badge in Sessions tab
- [x] Switching back to a worktree session focuses the correct Ghostty tab (when no same-cwd collision)
- [x] Resume worktree session works
- [x] Invalid worktree names rejected (shell metachars, leading dash, etc.)
- [x] Tab/click inside dialog don't fire background shortcuts
- [ ] Non-Ghostty terminals (iTerm2/Terminal.app/cmux) still work as before
- [ ] `yarn make` build OK (no debug logs in production)

## Known limitations / future work

These are **pre-existing** issues that became more visible with worktree sessions but are not specific to this PR. Documented for follow-up:

- **Same-cwd switch ambiguity (Ghostty).** When multiple Ghostty windows report the same cwd (e.g., a `yarn start` window + the active conversation window + an old worktree window all at `~/git/codev`), Layer-2 cwd match returns the first window in iteration order — often the top-most. Workaround: use `-n` / `/rename` to disambiguate via title match. Real fix waits on Ghostty TTY exposure.

- **Status indicator occasionally orange when expected green.** Worktree sessions that should be idle sometimes show the working/needs-attention orange dot. Cause TBD — may be hook timing or status-file race. Tracked separately.

- **Old worktree sessions** launched without `-n` (before this PR) won't have a custom title and will still hit the cwd-collision issue when switching. Workaround: exit + re-launch.

- **Non-alive worktree sessions don't show a branch name.** Claude CLI may auto-cleanup the worktree directory on clean exit, breaking the `git -C <worktree-path> branch` lookup. Branch info for cleaned-up worktrees is a future enhancement.

- **Nested worktree visibility in IDE/git GUI.** Because `claude -w` places worktrees at `<repo>/.claude/worktrees/<name>`, VS Code's file explorer and git GUI tools see those folders inside the workspace. Mitigation: add `.claude/worktrees/` to `.gitignore`, or revisit Approach A in a future PR.

- **AppleScript `activate` timing investigated, kept top-of-block.** Moving `activate` into match-success branches showed a perceptible slowdown in switch latency in local testing. Reverted; the visual glitch on match-miss is documented as a manifestation of the same-cwd ambiguity above, not a separate bug.

- **Resume with worktree-aware context.** Codev resumes worktree sessions via `cd <path> && claude --resume <uuid>`. Claude CLI also supports `claude --worktree <name> --resume <uuid>` which preserves keep/remove prompts on next exit. Codev could detect `isWorktree` and use the worktree-aware form — future enhancement.

- **Drop `-n` once Ghostty exposes TTY** ([ghostty#11354](https://github.com/ghostty-org/ghostty/pull/11354)).

_🤖 On behalf of @grimmerk — generated with Claude Code_
