### PR TITLE
feat: multi-account support (Batch 1) — CLI + CodeV sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.0.76
+
+- Feat: multi-account support (Batch 1) — run multiple Claude Code accounts (e.g. personal + work) from one machine
+  - Sessions tab aggregates sessions across all accounts (recency-merged), badges non-default accounts, and resumes each under its own account (`CLAUDE_CONFIG_DIR`)
+  - Per-account active dots, custom titles/branches, previews, and status hooks
+  - CLI helpers via `~/.config/codev/accounts.sh`: `claude <account>` / `claude-<account>`, `claude-whoami`, `claude-accounts`
+  - Fully opt-in: with no `~/.config/codev/accounts.json` registry (or a single account), CodeV behaves exactly as before
+  - Setup is manual for now (registry + `accounts.sh`); a management UI/CLI is planned. VS Code sessions can't be account-switched (#121). See `docs/multi-account-support-design.md`.
+
 ## 1.0.75
 
 - Feat: Sessions search clears after opening a session

--- a/docs/multi-account-support-design.md
+++ b/docs/multi-account-support-design.md
@@ -361,15 +361,17 @@ and **(d)** for CodeV, backed by the same `projectMap` in the registry so both a
 
 ## 7. Phasing (agreed)
 
-- **Batch 1 — now (satisfies 1, 2, 4.1, 5-min, 7, 8):**
-  - *P0 CLI:* registry; per-account functions + `claude <account>` dispatcher (§6.A a+b);
+- **Batch 1 — ✅ Done** (branch `feat/multi-account-support`) **(satisfies 1, 2, 4.1, 5-min, 7, 8):**
+  - *P0 CLI:* registry (`~/.config/codev/accounts.json`); per-account functions +
+    `claude <account>` dispatcher + `claude-whoami` / `claude-accounts` (§6.A);
     shell integration via a sourced file + one rc line (§6.C b); semi-manual add-account
-    (first `claude-<label>` run walks through login). §3.3 already confirmed.
-  - *P1 CodeV:* multi-dir session aggregation + **account badge** (needed to make the
-    merged list legible; shown only when ≥2 accounts) + account-aware resume/launch
-    (§6.E); hooks registered per config dir (§6.F). Biggest CodeV change; required even
-    for the "minimum," since CodeV can't show/resume account-2 sessions without scanning
-    account-2's dir.
+    (first `claude-<label>` run walks through login). §3.3 confirmed.
+  - *P1 CodeV:* multi-dir session aggregation + **account badge** (non-default accounts
+    only) + account-aware resume/launch (§6.E); active-dot + title/branch enrichment per
+    account; same-cwd cross-ref per account; hooks registered per config dir (§6.F).
+  - *Deferred:* VS Code (`claude-vscode`) sessions can't be account-switched (URI-handler
+    launch) — tracked in grimmerk/codev#121. Setup UI/CLI is Batch 2 (registry +
+    `accounts.sh` are hand-created for now).
 - **Batch 2 — after Batch 1, revisit:** account picker / per-launch override (§6.G, 4.2);
   manage-accounts Settings tab — list/add/rename/remove + shell-integration toggle
   (§6.D); pyenv-style folder auto-switch + terminal-side resume-to-right-account (§6.H).
@@ -423,5 +425,25 @@ No CLI/PATH helper exists today; the hook installer is the reference pattern.
 - **`~/.claude.json` at the old path:** some third-party tools still read
   `~/.claude.json` directly; with per-dir `.claude.json`, only the default account's is
   at the legacy path. Low impact for CodeV (we read per dir), but worth noting.
-</content>
-</invoke>
+
+---
+
+## 11. How to use it now (Batch 1, manual setup)
+
+Batch 1 ships the *engine*; account setup is manual until the Batch 2 UI/CLI.
+
+- **Registry** — `~/.config/codev/accounts.json`: one entry per account with
+  `label`, `dir`, `configDirEnv` (null for the default), `identityFile`, `isDefault`.
+  The default account is `~/.claude` (its `.claude.json` sits at `~/.claude.json`,
+  HOME level — never set `CLAUDE_CONFIG_DIR=~/.claude`, see §3.4). Extra accounts
+  live in `~/.claude-<label>`.
+- **Shell** — `~/.config/codev/accounts.sh` (sourced from `~/.zshrc`) defines
+  `claude` (dispatcher), `claude-<label>`, `claude-whoami`, `claude-accounts`.
+  Add an account: create its registry entry, then run `claude-<label>` once and
+  complete the browser login (populates `~/.claude-<label>`).
+- **CodeV** — with the registry present and ≥2 accounts logged in, the Sessions
+  tab lists sessions from every account (recency-merged), badges non-default
+  accounts, resumes each under its own account, shows per-account active dots +
+  titles, and registers status hooks in each account's `settings.json`.
+- **No registry / one account** — CodeV behaves exactly as before; the feature is
+  invisible and opt-in (graceful fallback to a single default account).

--- a/docs/multi-account-support-design.md
+++ b/docs/multi-account-support-design.md
@@ -447,3 +447,35 @@ Batch 1 ships the *engine*; account setup is manual until the Batch 2 UI/CLI.
   titles, and registers status hooks in each account's `settings.json`.
 - **No registry / one account** — CodeV behaves exactly as before; the feature is
   invisible and opt-in (graceful fallback to a single default account).
+
+### Concrete example — personal (default) + work
+
+`~/.config/codev/accounts.json`:
+
+```json
+{
+  "version": 1,
+  "defaultAccount": "personal",
+  "accounts": [
+    { "label": "personal", "dir": "/Users/you/.claude",       "identityFile": "/Users/you/.claude.json",            "configDirEnv": null,                        "isDefault": true },
+    { "label": "work",     "dir": "/Users/you/.claude-work",  "identityFile": "/Users/you/.claude-work/.claude.json", "configDirEnv": "/Users/you/.claude-work", "isDefault": false }
+  ]
+}
+```
+
+`~/.config/codev/accounts.sh` (then add `[ -f ~/.config/codev/accounts.sh ] && source ~/.config/codev/accounts.sh` to `~/.zshrc`):
+
+```bash
+claude-personal() { command claude "$@"; }                                   # default: NO CLAUDE_CONFIG_DIR
+claude-work()     { CLAUDE_CONFIG_DIR="$HOME/.claude-work" command claude "$@"; }
+claude() { case "$1" in                                                        # `claude work …` / bare `claude`
+  personal) shift; command claude "$@" ;;
+  work)     shift; CLAUDE_CONFIG_DIR="$HOME/.claude-work" command claude "$@" ;;
+  *)               command claude "$@" ;;
+esac }
+```
+
+Then run `claude-work` once and complete the browser login (populates
+`~/.claude-work`). Restart CodeV so it registers status hooks in the work
+account's `settings.json`. (`claude-whoami` / `claude-accounts` helpers can be
+added the same way — see the generated file for the full set.)

--- a/docs/multi-account-support-design.md
+++ b/docs/multi-account-support-design.md
@@ -131,8 +131,8 @@ global keychain item `Claude Code-credentials`, which is why tools like *claudin
 keychain items — 2.1.201 does not).
 
 **Result (verified 2026-07, CC 2.1.201):** with the default account
-(`grimmer0125@gmail.com`, Max) logged in at `~/.claude`, logging a *different* account
-(`grimmer@fireflies.ai`, Team) into `~/.claude-ma-test` produced two live sessions
+(a personal Max account) logged in at `~/.claude`, logging a *different* account
+(a work Team account) into `~/.claude-ma-test` produced two live sessions
 **simultaneously** (each `claude auth status` reported its own account); logging out the
 test dir left the default account **still logged in**. So `CLAUDE_CONFIG_DIR` alone is
 the whole mechanism — no `CLAUDE_CODE_OAUTH_TOKEN` needed — and accounts can run
@@ -188,6 +188,8 @@ Single source of truth (registry), read by both the shell layer and CodeV:
      ],
      "projectMap": { "/Users/me/git/work-repo": "work" }   // §6.H, optional
    }
+   // Simplified sketch — each entry also records `configDirEnv`, `identityFile`,
+   // and `isDefault`; see §11 for the full copy-paste schema.
 ```
 
 Launching account X = `CLAUDE_CONFIG_DIR=<X.dir> claude …` **for extra accounts**; the

--- a/docs/multi-account-support-design.md
+++ b/docs/multi-account-support-design.md
@@ -1,0 +1,427 @@
+# Multi-Account Support — Design Doc
+
+Status: **Draft / for review.** Covers CLI-level multi-account for Claude Code plus
+CodeV Sessions-tab integration. Verified against Claude Code **2.1.201** on macOS.
+
+---
+
+## 0. TL;DR
+
+- **Model: one Claude Code config dir per account** via `CLAUDE_CONFIG_DIR`.
+  Default account stays at `~/.claude`; each extra account is `~/.claude-<label>`
+  (e.g. `~/.claude-personal`). Verified that this isolates sessions, settings,
+  account identity (`.claude.json` → `oauthAccount`), and — pending one final
+  interactive check (§3.3) — credentials.
+- **CodeV never touches tokens.** It only ever sets `CLAUDE_CONFIG_DIR` and launches
+  the official `claude` binary. This keeps us inside Anthropic's "using the official
+  product" safe harbor (§2) regardless of how the third-party-token policy swings.
+- **CLI:** CodeV generates thin per-account shell functions (`claude-personal …`)
+  and, optionally, a `claude <account> …` dispatcher, installed via a single sourced
+  file. All native flags (`-r`, `--resume`, `mcp`, …) pass through untouched.
+- **CodeV Sessions:** scan **every** registered config dir, tag each session with its
+  account, show an account badge, and resume/launch with that account's
+  `CLAUDE_CONFIG_DIR`. This makes "resume with the account it was opened with"
+  (requirement 4.1) fall out for free — the account *is* the config dir the session
+  lives in.
+- **Cross-account file reuse:** per-project `CLAUDE.md` / `.claude/` are already
+  shared (they live in the project). Global `CLAUDE.md` / skills / commands / plugins /
+  settings are shareable via opt-in symlinks. Session data is intentionally *not*
+  shared — it is aggregated for display instead.
+
+---
+
+## 1. Requirements (traceability)
+
+| # | Requirement | Priority | Where addressed |
+|---|-------------|----------|-----------------|
+| 1 | CLI can pick account: `claude --account2` / `claude personal` | Must | §6.A |
+| 2 | Preserve all existing `claude` behavior (`-r`, etc.) | Must | §6.A |
+| 3 | Env-var points at account/config folder | (mechanism) | §3, §4 |
+| 4.1 | CodeV resume/reopen uses the session's original account | Must | §6.E |
+| 4.2 | CodeV: optionally pick a different account | Nice | §6.G |
+| 5 | CLI multi-account config easy (must); CodeV config (nice) | Must/Nice | §6.C, §6.D, §6.G |
+| 6 | pyenv-style auto-switch by project folder | Nice | §6.H |
+| 7 | UI/UX fits current Sessions/Projects/Settings | Must | §6.E, §6.G |
+| 8 | CLI installed by CodeV (auto or on-click), hook-style | Must | §6.C |
+
+---
+
+## 2. Is this allowed? (ToS / third-party-token policy)
+
+**Having multiple personal accounts is not a ToS violation.** Anthropic staff have
+stated it is fine to hold multiple Max accounts; the personal ↔ Team/Enterprise
+switch is an officially supported flow.
+
+**What *is* prohibited** is (a) sharing/reselling a single account across people, and
+(b) *using subscription (Free/Pro/Max) OAuth tokens in another product, tool, or
+service — including the Agent SDK*. This second rule is the one whose enforcement
+messaging has flip-flopped over time (the "we'll block subscription-auth in
+third-party agents" back-and-forth).
+
+**Why CodeV is unaffected — three tiers of "using a subscription":**
+
+| Tier | Example | Policy |
+|------|---------|--------|
+| ① Run the official `claude` binary (any flags, incl. `-p`) | CodeV launching `claude` | ✅ Always sanctioned |
+| ② A third-party tool uses the subscription OAuth token to drive the model | OpenCode/Cline with Max login; Agent SDK on a subscription token | ⚠️ The contested/prohibited zone |
+| ③ API key | pay-as-you-go | ✅ Separate, unrelated |
+
+CodeV lives entirely in tier ①: it sets an env var and execs the official CLI. It
+**never reads the OAuth token, never calls the model, never embeds an agent.** Even
+`claude auth status` (used only to label accounts) makes no model call. Self-imposed
+red line: **CodeV must never drive the model using a subscription token** — stay a
+launcher, not an agent.
+
+---
+
+## 3. Verified mechanism (foundation)
+
+### 3.1 What `CLAUDE_CONFIG_DIR` relocates (empirically confirmed)
+
+Running `CLAUDE_CONFIG_DIR=/tmp/x claude -p "…"` created:
+
+```
+/tmp/x/.claude.json          ← moved here (holds oauthAccount identity, per-project state, MCP user config)
+/tmp/x/projects/…            ← session history / transcripts
+/tmp/x/sessions/             ← active-session PID files
+/tmp/x/backups/
+```
+
+So **the entire per-user Claude state — including `.claude.json` and its
+`oauthAccount` block — is config-dir-scoped.** (Note: this contradicts a claim in
+some docs that `.claude.json` stays at `~/.claude.json`; on 2.1.201 it moves. Tested.)
+
+Also relocated when present: `settings.json`, `history.jsonl`, `skills/`, `commands/`,
+`plugins/`, `todos/`, `shell-snapshots/`, `codev-status/` is **not** (see §6.F).
+
+### 3.2 Fresh config dir = separate account (confirmed)
+
+`CLAUDE_CONFIG_DIR=/tmp/x claude -p "OK"` on a **fresh** dir returned:
+
+```
+Not logged in · Please run /login
+```
+
+even though the default account (`~/.claude`) is logged in. So Claude Code does **not**
+fall back to the default account's credentials for a different config dir → the
+credential lookup is effectively **keyed by config dir**. This is what makes
+config-dir-per-account a *true* account switch on macOS, not just a settings swap.
+
+Useful side-finding: **`claude auth status` prints clean JSON** and is config-dir
+aware:
+
+```json
+{ "loggedIn": true, "authMethod": "claude.ai", "apiProvider": "firstParty",
+  "email": "…", "orgId": "…", "orgName": "…", "subscriptionType": "max" }
+```
+
+CodeV can label accounts either by reading `$DIR/.claude.json` → `oauthAccount.emailAddress`
+(fast, pure file read, no subprocess, no model call) or by running
+`CLAUDE_CONFIG_DIR=$DIR claude auth status` (authoritative, handles token expiry).
+
+`claude auth` subcommands exist and are the official surface: `login`, `logout`,
+`status`. There is **no** `--profile` / `--config-dir` flag — the env var is the only
+switch.
+
+### 3.3 Confirmed: credentials are isolated per config dir ✅
+
+The fresh-dir test proved a new dir *starts* logged-out; a second test proved that
+**logging into account 2 does not disturb account 1** (older Claude Code kept a single
+global keychain item `Claude Code-credentials`, which is why tools like *claudini* swap
+keychain items — 2.1.201 does not).
+
+**Result (verified 2026-07, CC 2.1.201):** with the default account
+(`grimmer0125@gmail.com`, Max) logged in at `~/.claude`, logging a *different* account
+(`grimmer@fireflies.ai`, Team) into `~/.claude-ma-test` produced two live sessions
+**simultaneously** (each `claude auth status` reported its own account); logging out the
+test dir left the default account **still logged in**. So `CLAUDE_CONFIG_DIR` alone is
+the whole mechanism — no `CLAUDE_CODE_OAUTH_TOKEN` needed — and accounts can run
+concurrently in separate terminals. The test used:
+
+```bash
+CLAUDE_CONFIG_DIR="$HOME/.claude-ma-test" claude auth login   # interactive; log in
+claude auth status                                            # expect: still logged in (default untouched)
+CLAUDE_CONFIG_DIR="$HOME/.claude-ma-test" claude auth logout
+claude auth status                                            # KEY: still logged in ⇒ isolated ✅ ; logged out ⇒ shared keychain ❌
+rm -rf "$HOME/.claude-ma-test"
+```
+
+- **Isolated (confirmed):** `CLAUDE_CONFIG_DIR` alone is the whole mechanism.
+- **Fallback (not needed):** had it been a shared keychain, we would add a per-account
+  `CLAUDE_CODE_OAUTH_TOKEN` (from `claude setup-token`) to each launch — kept here only
+  as a note; the design does not use it.
+
+---
+
+### 3.4 The default account is special — leave `CLAUDE_CONFIG_DIR` *unset* ⚠️
+
+The default account (unset `CLAUDE_CONFIG_DIR`) keeps its `.claude.json` at
+**`~/.claude.json` (HOME level)**, while its dir contents (`history.jsonl`, `projects/`,
+`sessions/`, `settings.json`) live in `~/.claude/`. A *custom* config dir instead keeps
+**everything inside the dir**, including `<dir>/.claude.json`.
+
+Consequence (verified — it cost us a test): `CLAUDE_CONFIG_DIR="$HOME/.claude"` does
+**NOT** reproduce the default account. Claude then looks for `~/.claude/.claude.json`
+(absent), reports "config not found," appears logged out, and drops a stray empty
+`~/.claude/.claude.json`. Therefore:
+
+- **Default account ⇒ NO `CLAUDE_CONFIG_DIR`.** Identity read from `~/.claude.json`.
+- **Extra account ⇒ `CLAUDE_CONFIG_DIR=~/.claude-<label>`.** Identity at `<dir>/.claude.json`.
+- Session data (`history.jsonl` / `projects` / `sessions`) is under `<dir>/` for BOTH
+  (default dir = `~/.claude`), so CodeV scans by `dir` uniformly; only the identity-file
+  path and the launch prefix differ by whether the account is the default.
+
+## 4. Architecture: config-dir-per-account
+
+```
+~/.claude                    → account "default"  (existing, untouched)
+~/.claude-personal           → account "personal"
+~/.claude-work               → account "work"
+   each: .claude.json (identity), settings.json, projects/, sessions/, history.jsonl,
+         skills/, commands/, plugins/   (credentials via per-dir-keyed keychain)
+
+Single source of truth (registry), read by both the shell layer and CodeV:
+~/.config/codev/accounts.json
+   { "accounts": [
+       { "label": "default",  "dir": "~/.claude",          "email": "…", "sub": "max" },
+       { "label": "personal", "dir": "~/.claude-personal",  "email": "…", "sub": "pro" }
+     ],
+     "projectMap": { "/Users/me/git/work-repo": "work" }   // §6.H, optional
+   }
+```
+
+Launching account X = `CLAUDE_CONFIG_DIR=<X.dir> claude …` **for extra accounts**; the
+**default account launches with NO prefix** (see §3.4 — never `CLAUDE_CONFIG_DIR=~/.claude`).
+Identity file per account: default → `~/.claude.json` (HOME); extra → `<dir>/.claude.json`.
+The registry records `configDirEnv` (null for default, the dir for extras) and
+`identityFile`, so CodeV derives the launch prefix + identity without special-casing.
+
+---
+
+## 5. Cross-account file reuse (answering the reuse question)
+
+| File / data | Scope | Shared across accounts? | How |
+|---|---|---|---|
+| Project `CLAUDE.md` (`<repo>/CLAUDE.md`) | Project folder | **Yes, automatically** | Lives in the repo; account-independent |
+| Project `.claude/` (settings, commands, local memory) | Project folder | **Yes, automatically** | Same — in the repo |
+| Global `~/.claude/CLAUDE.md` (user instructions) | Config dir | No by default → **opt-in symlink** | `ln -s ~/.claude/CLAUDE.md ~/.claude-x/CLAUDE.md` |
+| Global `skills/`, `commands/`, `plugins/` | Config dir | No by default → **opt-in symlink** | symlink the dir |
+| `settings.json` (model, hooks, permissions, env) | Config dir | Optional symlink (careful) | Symlink ⇒ hooks/permissions shared; or install hook per-dir (§6.F) |
+| `.claude.json` (identity + per-project trust) | Config dir | **No — never symlink** | Holds `oauthAccount`; must stay per-account |
+| Auto-memory (`projects/<path>/memory/`, `MEMORY.md`) | Config dir | No by default | Per-account, or advanced: symlink individual `memory/` subdirs |
+| Session data (`history.jsonl`, `projects/*.jsonl`, `sessions/`) | Config dir | **No — aggregated for display, not shared** | CodeV scans all dirs (§6.E) |
+
+Your guess was right: **per-project files are account-independent; only the global
+files need help.** "Reusing" session data across accounts isn't actually desirable —
+each account owns its sessions; what you want is CodeV *showing* them all, which §6.E
+does.
+
+CodeV's "Add account" flow (§6.D) offers per-item checkboxes: *Share global CLAUDE.md
+/ skills / commands / plugins / settings with the default account?* → creates the
+symlinks. `.claude.json` is never offered.
+
+---
+
+## 6. Sub-feature designs (approaches, pros/cons, recommendation)
+
+### 6.A CLI: invoking a specific account
+
+| Approach | How | Pros | Cons |
+|---|---|---|---|
+| **(a) Per-account functions** *(rec, baseline)* | `claude-personal(){ CLAUDE_CONFIG_DIR=~/.claude-personal claude "$@"; }` generated per account | Dead simple; `"$@"` passes **all** native flags perfectly (`-r`, `mcp`, completion unaffected); zero shadowing risk | One function per account; naming |
+| **(b) `claude <account>` dispatcher** *(rec, add-on)* | Wrap `claude` so `claude personal -r` → route to personal; first arg matched against account labels, everything else passthrough (built on the existing `claude2` passthrough pattern) | Matches your "claude personal" mental model; one entry point | Shadows the real `claude` — must carefully passthrough subcommands/flags; slightly more fragile |
+| (c) Compiled dispatcher (Rust/Bun on PATH) | A `cv`/`claudex` binary resolves account → `execvp` real claude | Robust; could also do §6.H auto-switch and read the registry | A binary to build/ship/update; PATH-ordering vs real `claude`; overkill for v1 |
+
+**Recommendation:** ship **(a)** as the robust baseline; add **(b)** for ergonomics
+(guard the shadow with a strict label match + full passthrough, exactly like the
+user's existing `claude2`). Defer **(c)** unless §6.H auto-switch grows enough logic to
+justify a binary. `--account2`-style flags are *not* recommended as the primary form
+(a flag on a shadowed `claude` is more error-prone than a first-arg label or a named
+function).
+
+**Query helpers (the reverse — "which account am I on?"):** `claude-whoami` prints the
+account that this shell's bare `claude` resolves to (respects `CLAUDE_CONFIG_DIR`;
+unset ⇒ the default), with our label + a live `claude auth status`; `claude-accounts`
+lists all. These ship in Batch 1 (they make the imminent smoke-test legible and answer
+"what does the default map to"). Do **not** expose them as `claude whoami` — a bare
+first-arg would be swallowed by the dispatcher / passed to real `claude`; use distinct
+function names. Batch 2 folds them into `codev account current | list | default`.
+
+### 6.B Account registry (source of truth)
+
+- **`~/.config/codev/accounts.json`** (plain JSON), owned/written by CodeV, readable
+  by the shell layer via `jq`. The generated shell functions are **static** (one per
+  account) so they need no runtime lookup — regenerated only when accounts change.
+- Alternative: keep it inside CodeV's `electron-settings`
+  (`~/Library/Application Support/CodeV/settings.json`, new `accounts` key). The shell
+  side can still read it with `jq`, but a dedicated file is cleaner and shell-friendly.
+- **Recommendation:** dedicated `~/.config/codev/accounts.json`; mirror the label/email
+  into CodeV settings only as a cache.
+
+### 6.C CLI shell integration install (requirement 8, hook-style)
+
+| Approach | Pros | Cons |
+|---|---|---|
+| (a) Auto-append a managed block to `~/.zshrc` (`# >>> codev accounts >>>` markers) | Fully automatic | Edits the user's rc; must be idempotent + cleanly removable; shell detection (zsh/bash/fish) |
+| **(b) Write `~/.config/codev/accounts.sh`; user adds one `source` line** *(rec)* | Minimal footprint; regenerating accounts never re-touches rc; easy to audit | One manual step (or a guided one-click for the single source line) |
+| (c) Settings shows the snippet for manual copy | Zero filesystem risk | Least convenient |
+
+**Recommendation:** **(b)** + a one-click "Install shell integration" button (Settings)
+that appends a single marker-guarded `source ~/.config/codev/accounts.sh` to the
+detected rc, with **(c)** as manual fallback. Mirrors the existing Session-Status hook
+toggle (write file with `0o755`, register a reference, idempotent, removable). Detect
+shell; warn if not zsh/bash.
+
+### 6.D Add-account (login) bootstrap
+
+OAuth is interactive (browser) — CodeV cannot automate it, only orchestrate it.
+
+Flow: **Settings → Accounts → "Add account"** → prompt for a label →
+`mkdir ~/.claude-<label>` → spawn the configured terminal running
+`CLAUDE_CONFIG_DIR=~/.claude-<label> claude auth login` → user completes OAuth →
+CodeV polls `~/.claude-<label>/.claude.json` for `oauthAccount` → saves to registry →
+offer the reuse-symlink checkboxes (§5) → regenerate `accounts.sh`.
+
+Optional headless path for power users: `claude setup-token` → store
+`CLAUDE_CODE_OAUTH_TOKEN` per account (also the §3.3 fallback).
+
+### 6.E CodeV: multi-dir session aggregation + account-aware resume  ← core CodeV change
+
+Today CodeV reads a **hardcoded** `~/.claude` (history.jsonl at
+`claude-session-utility.ts:50-52`; `CLAUDE_DIR` at `session-status-hooks.ts:12-16`;
+`sessions/` scan at `:875-947`). To support accounts:
+
+1. **Aggregate:** iterate registered config dirs; for each, read its
+   `history.jsonl` / `projects/` / `sessions/`; tag every `ClaudeSession` with
+   `{ accountLabel, configDir }`. Merge into one sorted list.
+2. **Badge:** show a small account badge on each session row (same visual language as
+   the existing `ITERM2` badge). Hide badges entirely when only the default account
+   exists (zero UI change for single-account users).
+3. **Account-aware launch/resume — the injection:** at the command choke points, when
+   the session's account ≠ default, prefix `CLAUDE_CONFIG_DIR="<dir>" ` onto the
+   command:
+   - iTerm2 / Terminal.app: into `fullCommand` →
+     `cd "<path>" && CLAUDE_CONFIG_DIR="<dir>" claude --resume <id>`
+     (built in `runCommandInTerminal`, `claude-session-utility.ts:1157-1310`; resume
+     else-branches at `:1531/:1808`).
+   - Ghostty / cmux: into `claudeCmd` (cwd is passed separately) — `:1746/:1827`.
+   - CodeV embedded term: prepend to the `cmd` string (`main.ts:1124`) or set the pty
+     `env` (`main.ts:1850`).
+   - New session: `launchNewClaudeSession` (`:1347`).
+   - **VS Code: not possible** (launch is a URI handler, no shell/env — `:1321-1339`).
+     VS Code sessions' account is whatever the VS Code extension is signed into;
+     out of scope for CodeV env injection. Note in UI.
+4. **Result:** requirement 4.1 is automatic — a session's account is the dir it was
+   read from, so resuming re-injects exactly that account.
+
+Use absolute paths (not `~`) in the injected string to avoid tilde-expansion issues
+inside AppleScript.
+
+### 6.F CodeV: status hooks across accounts
+
+The hook **script** already writes to a fixed `~/.claude/codev-status/<id>.json`
+(absolute, not `$CLAUDE_CONFIG_DIR`), so **one watch dir still sees every account** —
+good. But the hook must be **registered** in each account's `settings.json`. Options:
+
+- **(a)** `installHooks()` (`session-status-hooks.ts:73-116`) loops over all registered
+  config dirs and merges the hook entry into each `settings.json`. *(rec — explicit,
+  survives un-symlinked settings.)*
+- **(b)** Symlink account settings.json to the default (§5) so the hook is inherited.
+  Simpler but couples all settings.
+
+**Recommendation:** (a). Keep the fixed status dir; register per dir.
+
+### 6.G CodeV: optional account picker (requirement 4.2, nice-to-have)
+
+- Resume normally uses the session's own account (§6.E). For the rare "resume this
+  transcript under a different account" case, add a modifier (e.g. long-press / a
+  small dropdown in an expanded row) listing accounts. Note that resuming a transcript
+  under a *different* account may not find it (session history is per-dir), so this is
+  really "start a new session in this cwd under account Y" — align the UX wording.
+- New-session launch (Projects `⌘+Enter`): allow an account override, e.g. extend the
+  planned `>` command mode (`> claude @work myrepo`) or an account segment in the
+  expanded project row.
+
+### 6.H pyenv-style auto-switch by folder (requirement 6, nice-to-have, "reverse" priority)
+
+**Caution first:** never `export CLAUDE_CONFIG_DIR` globally — it would hijack *every*
+claude (including CodeV-launched ones). Auto-switch must be per-invocation/per-shell.
+
+| Approach | How | Pros | Cons |
+|---|---|---|---|
+| **(a) `.claude-account` file in repo + zsh `chpwd` hook** *(rec)* | `chpwd` reads the file, sets `CLAUDE_CONFIG_DIR` for that shell | pyenv-like; per-repo; committable or git-ignored | Needs a `chpwd` hook; zsh-specific |
+| (b) `direnv` `.envrc` with `export CLAUDE_CONFIG_DIR=…` | Reuse a battle-tested tool | Robust, scoped | Extra dependency; per-repo `.envrc` |
+| (c) Registry `projectMap` read by the `claude` wrapper | Wrapper matches cwd prefix → account | Central; no per-repo file; shared with CodeV | Only works through the wrapper; wrapper complexity |
+| (d) CodeV `projectMap` (UI) | CodeV launches use it | Great for CodeV-initiated launches | Doesn't cover raw terminal `cd && claude` |
+
+**Recommendation:** defer to a later phase. When built, do **(a)** for the terminal
+and **(d)** for CodeV, backed by the same `projectMap` in the registry so both agree.
+
+---
+
+## 7. Phasing (agreed)
+
+- **Batch 1 — now (satisfies 1, 2, 4.1, 5-min, 7, 8):**
+  - *P0 CLI:* registry; per-account functions + `claude <account>` dispatcher (§6.A a+b);
+    shell integration via a sourced file + one rc line (§6.C b); semi-manual add-account
+    (first `claude-<label>` run walks through login). §3.3 already confirmed.
+  - *P1 CodeV:* multi-dir session aggregation + **account badge** (needed to make the
+    merged list legible; shown only when ≥2 accounts) + account-aware resume/launch
+    (§6.E); hooks registered per config dir (§6.F). Biggest CodeV change; required even
+    for the "minimum," since CodeV can't show/resume account-2 sessions without scanning
+    account-2's dir.
+- **Batch 2 — after Batch 1, revisit:** account picker / per-launch override (§6.G, 4.2);
+  manage-accounts Settings tab — list/add/rename/remove + shell-integration toggle
+  (§6.D); pyenv-style folder auto-switch + terminal-side resume-to-right-account (§6.H).
+- **Batch 3 — later:** cross-account symlink reuse of global files
+  (CLAUDE.md / skills / commands / plugins / settings, §5).
+
+---
+
+## 8. Key code touch-points (from the code map)
+
+| Area | File:line | Change |
+|---|---|---|
+| Session list path | `claude-session-utility.ts:50-52` | Loop over config dirs |
+| Active-session scan | `claude-session-utility.ts:875-947` | Per dir; tag account |
+| Enrichment/project encoding | `:1096-1129, :1555-1632` | Per dir |
+| Launch new | `:1316-1348` (`:1347`) | Inject `CLAUDE_CONFIG_DIR` prefix |
+| Resume choke points | `runCommandInTerminal :1157-1310`; else-branches `:1531,:1746,:1808,:1827/1953` | Inject prefix |
+| CodeV term | `main.ts:1124` / pty env `main.ts:1850` | Prefix or env |
+| Settings storage | `electron-settings` (`main.ts:12`) + new IPC pair | `accounts` cache |
+| Settings UI | `popup.tsx` (Sessions/General) | Accounts section |
+| Hooks install | `session-status-hooks.ts:73-116` | Loop over config dirs |
+| CLI helper (new) | modeled on `session-status-hooks.ts` `installHooks()` | Write `accounts.sh`, source line |
+
+No CLI/PATH helper exists today; the hook installer is the reference pattern.
+
+---
+
+## 9. Open decisions (for review)
+
+1. **Start scope:** Phase 0 only, Phase 0+1, or full?
+2. **CLI form:** per-account functions only, or also the `claude <account>` dispatcher?
+3. **Shell install invasiveness:** auto-append to `~/.zshrc`, or write file + one
+   sourced line, or manual snippet only?
+4. **Account labels:** free-form (`personal`, `work`) — confirm naming + the config-dir
+   pattern `~/.claude-<label>`.
+5. **§3.3 credential test:** run now (recommended) or proceed on current evidence?
+
+---
+
+## 10. Risks & gotchas
+
+- **Global `export CLAUDE_CONFIG_DIR` hijacks everything** — only ever set it
+  per-invocation (§6.H caution).
+- **§3.3 unconfirmed** — if login-2 clobbers login-1, fall back to per-account
+  `CLAUDE_CODE_OAUTH_TOKEN` (rest of design unchanged).
+- **VS Code sessions** can't be account-switched from CodeV (URI-handler launch).
+- **rc-file editing** must be idempotent, marker-guarded, removable; detect shell.
+- **`.claude.json` must never be symlinked** across accounts (identity + trust).
+- **Hook registration per dir** or symlinked settings — don't forget account-2's
+  `settings.json`, or its sessions get no status dots.
+- **`~/.claude.json` at the old path:** some third-party tools still read
+  `~/.claude.json` directly; with per-dir `.claude.json`, only the default account's is
+  at the legacy path. Low impact for CodeV (we read per dir), but worth noting.
+</content>
+</invoke>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "CodeV",
   "productName": "CodeV",
-  "version": "1.0.75",
+  "version": "1.0.76",
   "description": "Quick switcher for VS Code, Cursor, and Claude Code sessions",
   "repository": {
     "type": "git",

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -103,7 +103,8 @@ export const getAccounts = (): CodevAccount[] => {
         // Tolerate a partial registry entry: if isDefault is omitted, infer it
         // from the top-level defaultAccount label.
         const isDefault =
-          a.isDefault ?? (!!raw.defaultAccount && a.label === raw.defaultAccount);
+          a.isDefault ??
+          (!!raw.defaultAccount && a.label === raw.defaultAccount);
         const configDirEnv =
           a.configDirEnv === null || a.configDirEnv === undefined
             ? isDefault

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -162,3 +162,10 @@ export const getAccountByLabel = (label: string | undefined): CodevAccount => {
 
 /** True when more than one account is configured (used to gate account UI). */
 export const isMultiAccount = (): boolean => getAccounts().length > 1;
+
+/**
+ * A session's transcripts live under its account's config dir (`<dir>/projects`).
+ * Falls back to ~/.claude for sessions without an account tag (e.g. VS Code).
+ */
+export const getProjectsDir = (accountDir?: string): string =>
+  path.join(accountDir || path.join(os.homedir(), '.claude'), 'projects');

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -46,6 +46,7 @@ interface RawAccount {
 
 interface RawRegistry {
   accounts?: RawAccount[];
+  defaultAccount?: string;
 }
 
 const REGISTRY_PATH = path.join(
@@ -99,7 +100,10 @@ export const getAccounts = (): CodevAccount[] => {
         const dir = expandHome(
           String(a.dir || path.join(os.homedir(), '.claude')),
         );
-        const isDefault = !!a.isDefault;
+        // Tolerate a partial registry entry: if isDefault is omitted, infer it
+        // from the top-level defaultAccount label.
+        const isDefault =
+          a.isDefault ?? (!!raw.defaultAccount && a.label === raw.defaultAccount);
         const configDirEnv =
           a.configDirEnv === null || a.configDirEnv === undefined
             ? isDefault

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -1,0 +1,164 @@
+/**
+ * CodeV multi-account registry reader.
+ *
+ * Source of truth: ~/.config/codev/accounts.json (also consumed by the shell
+ * integration at ~/.config/codev/accounts.sh). When the registry is absent we
+ * fall back to a single default account (~/.claude), so single-account users
+ * keep today's exact behavior and see no new UI.
+ *
+ * Key nuance (see docs/multi-account-support-design.md §3.4): the DEFAULT account
+ * uses NO CLAUDE_CONFIG_DIR — its .claude.json is at ~/.claude.json (HOME), while
+ * its dir contents live in ~/.claude/. Extra accounts are fully self-contained in
+ * ~/.claude-<label>/. So:
+ *   - dir           = where session data lives (history.jsonl/projects/sessions) — always set
+ *   - configDirEnv  = CLAUDE_CONFIG_DIR to set at launch — null for the default account
+ *   - identityFile  = .claude.json path — ~/.claude.json for default, <dir>/.claude.json otherwise
+ */
+
+import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
+
+export interface CodevAccount {
+  label: string;
+  dir: string; // config dir for session scanning (default account: ~/.claude)
+  configDirEnv: string | null; // CLAUDE_CONFIG_DIR at launch; null => default account (unset)
+  identityFile: string; // .claude.json path (HOME for default, <dir>/.claude.json otherwise)
+  isDefault: boolean;
+  email?: string;
+  org?: string;
+  subscription?: string;
+  loggedIn?: boolean;
+}
+
+/** Shape of an entry in accounts.json (all optional — we coerce/validate). */
+interface RawAccount {
+  label?: string;
+  dir?: string;
+  configDirEnv?: string | null;
+  identityFile?: string;
+  isDefault?: boolean;
+  email?: string;
+  org?: string;
+  subscription?: string;
+  loggedIn?: boolean;
+}
+
+interface RawRegistry {
+  accounts?: RawAccount[];
+}
+
+const REGISTRY_PATH = path.join(
+  os.homedir(),
+  '.config',
+  'codev',
+  'accounts.json',
+);
+
+const expandHome = (p: string): string =>
+  p.startsWith('~') ? path.join(os.homedir(), p.slice(1)) : p;
+
+const makeDefaultAccount = (): CodevAccount => ({
+  label: 'default',
+  dir: path.join(os.homedir(), '.claude'),
+  configDirEnv: null,
+  identityFile: path.join(os.homedir(), '.claude.json'),
+  isDefault: true,
+});
+
+let cached: CodevAccount[] | null = null;
+let cacheTimestamp = 0;
+const CACHE_TTL_MS = 5000;
+
+export const invalidateAccountsCache = (): void => {
+  cached = null;
+};
+
+/**
+ * All configured accounts. Always returns at least one (the default).
+ * Cached for 5s to avoid re-reading the registry on every keystroke.
+ */
+export const getAccounts = (): CodevAccount[] => {
+  const now = Date.now();
+  if (cached && now - cacheTimestamp < CACHE_TTL_MS) {
+    return cached;
+  }
+
+  let accounts: CodevAccount[];
+  try {
+    if (!fs.existsSync(REGISTRY_PATH)) {
+      accounts = [makeDefaultAccount()];
+    } else {
+      const raw = JSON.parse(
+        fs.readFileSync(REGISTRY_PATH, 'utf-8'),
+      ) as RawRegistry;
+      const list: RawAccount[] = Array.isArray(raw?.accounts)
+        ? raw.accounts
+        : [];
+      accounts = list.map((a: RawAccount): CodevAccount => {
+        const dir = expandHome(
+          String(a.dir || path.join(os.homedir(), '.claude')),
+        );
+        const isDefault = !!a.isDefault;
+        const configDirEnv =
+          a.configDirEnv === null || a.configDirEnv === undefined
+            ? isDefault
+              ? null
+              : dir
+            : expandHome(String(a.configDirEnv));
+        const identityFile = a.identityFile
+          ? expandHome(String(a.identityFile))
+          : isDefault
+            ? path.join(os.homedir(), '.claude.json')
+            : path.join(dir, '.claude.json');
+        return {
+          label: String(a.label || 'default'),
+          dir,
+          configDirEnv,
+          identityFile,
+          isDefault,
+          email: a.email,
+          org: a.org,
+          subscription: a.subscription,
+          loggedIn: a.loggedIn,
+        };
+      });
+      if (accounts.length === 0) {
+        accounts = [makeDefaultAccount()];
+      }
+    }
+  } catch (error) {
+    console.error('Error reading codev accounts registry:', error);
+    accounts = [makeDefaultAccount()];
+  }
+
+  cached = accounts;
+  cacheTimestamp = now;
+  return accounts;
+};
+
+/**
+ * Accounts whose config dir actually exists on disk — i.e. worth scanning for
+ * sessions. A registered-but-not-yet-logged-in account (dir missing) is skipped.
+ */
+export const getScannableAccounts = (): CodevAccount[] =>
+  getAccounts().filter((a) => {
+    try {
+      return fs.existsSync(a.dir);
+    } catch {
+      return false;
+    }
+  });
+
+/** Look up an account by label (falls back to the default account). */
+export const getAccountByLabel = (label: string | undefined): CodevAccount => {
+  const accounts = getAccounts();
+  return (
+    accounts.find((a) => a.label === label) ||
+    accounts.find((a) => a.isDefault) ||
+    accounts[0]
+  );
+};
+
+/** True when more than one account is configured (used to gate account UI). */
+export const isMultiAccount = (): boolean => getAccounts().length > 1;

--- a/src/claude-session-utility.ts
+++ b/src/claude-session-utility.ts
@@ -25,6 +25,7 @@ export interface ClaudeSession {
   entrypoint?: string;     // 'cli', 'claude-vscode', etc.
   accountLabel?: string; // codev multi-account: which account this session belongs to
   accountDir?: string; // that account's config dir (session data + enrichment root)
+  accountConfigDirEnv?: string | null; // CLAUDE_CONFIG_DIR to set at resume (null = default)
   accountIsDefault?: boolean; // default account => no CLAUDE_CONFIG_DIR at launch
 }
 
@@ -51,6 +52,7 @@ interface SessionAccum {
   promptCount: number;
   accountLabel: string;
   accountDir: string;
+  accountConfigDirEnv: string | null;
   accountIsDefault: boolean;
 }
 
@@ -98,8 +100,10 @@ export const readClaudeSessions = (limit = 100): ClaudeSession[] => {
   // sessionIds are UUIDs (unique across accounts), so no cross-account dedupe.
   const bySession = new Map<string, SessionAccum>();
 
-  try {
-    for (const account of getScannableAccounts()) {
+  // Per-account try/catch: one unreadable/corrupt history must not hide the
+  // sessions of every other account.
+  for (const account of getScannableAccounts()) {
+    try {
       const historyPath = getHistoryPath(account.dir);
       if (!fs.existsSync(historyPath)) continue;
 
@@ -132,6 +136,7 @@ export const readClaudeSessions = (limit = 100): ClaudeSession[] => {
               promptCount: 1,
               accountLabel: account.label,
               accountDir: account.dir,
+              accountConfigDirEnv: account.configDirEnv,
               accountIsDefault: account.isDefault,
             });
           }
@@ -139,33 +144,33 @@ export const readClaudeSessions = (limit = 100): ClaudeSession[] => {
           // skip malformed lines
         }
       }
+    } catch (error) {
+      console.error(`Error reading Claude sessions for ${account.label}:`, error);
     }
-
-    // Unified timeline: sort the MERGED set by recency (newest first) so both
-    // accounts interleave by lastTimestamp. The account badge disambiguates.
-    const allSessions = Array.from(bySession.values())
-      .sort((a, b) => b.lastTimestamp - a.lastTimestamp)
-      .map((s) => ({
-        sessionId: s.sessionId,
-        project: s.project,
-        projectName: path.basename(s.project) || s.project,
-        firstUserMessage: s.firstDisplay,
-        lastUserMessage: s.lastDisplay,
-        lastTimestamp: s.lastTimestamp,
-        messageCount: s.promptCount,
-        isActive: false,
-        accountLabel: s.accountLabel,
-        accountDir: s.accountDir,
-        accountIsDefault: s.accountIsDefault,
-      }));
-
-    cachedSessions = allSessions;
-    cacheTimestamp = now;
-    return allSessions.slice(0, limit);
-  } catch (error) {
-    console.error('Error reading Claude sessions:', error);
-    return [];
   }
+
+  // Unified timeline: sort the MERGED set by recency (newest first) so both
+  // accounts interleave by lastTimestamp. The account badge disambiguates.
+  const allSessions = Array.from(bySession.values())
+    .sort((a, b) => b.lastTimestamp - a.lastTimestamp)
+    .map((s) => ({
+      sessionId: s.sessionId,
+      project: s.project,
+      projectName: path.basename(s.project) || s.project,
+      firstUserMessage: s.firstDisplay,
+      lastUserMessage: s.lastDisplay,
+      lastTimestamp: s.lastTimestamp,
+      messageCount: s.promptCount,
+      isActive: false,
+      accountLabel: s.accountLabel,
+      accountDir: s.accountDir,
+      accountConfigDirEnv: s.accountConfigDirEnv,
+      accountIsDefault: s.accountIsDefault,
+    }));
+
+  cachedSessions = allSessions;
+  cacheTimestamp = now;
+  return allSessions.slice(0, limit);
 };
 
 /**
@@ -1055,7 +1060,7 @@ const getResumeConfigDirEnv = (sessionId: string): string | null => {
   const s = readClaudeSessions(Number.MAX_SAFE_INTEGER).find(
     (x) => x.sessionId === sessionId,
   );
-  return s && !s.accountIsDefault && s.accountDir ? s.accountDir : null;
+  return s?.accountConfigDirEnv ?? null;
 };
 
 /**
@@ -2009,7 +2014,7 @@ export const openSessionInCmux = (
  */
 export const copyResumeCommand = (sessionId: string, projectPath: string): string => {
   const command = `cd "${projectPath}" && ${buildResumeCommand(sessionId)}`;
-  const { execSync } = require('child_process');
-  execSync(`echo "${command}" | pbcopy`);
+  const { execFileSync } = require('child_process');
+  execFileSync('pbcopy', { input: command });
   return command;
 };

--- a/src/claude-session-utility.ts
+++ b/src/claude-session-utility.ts
@@ -58,6 +58,11 @@ const getHistoryPath = (dir: string): string => {
   return path.join(dir, 'history.jsonl');
 };
 
+// codev multi-account: a session's transcripts live under its account's config
+// dir. Falls back to ~/.claude for sessions without an account tag (e.g. VS Code).
+const getProjectsDir = (accountDir?: string): string =>
+  path.join(accountDir || path.join(os.homedir(), '.claude'), 'projects');
+
 // Cache for parsed sessions to avoid re-reading history.jsonl on every keystroke
 let cachedSessions: ClaudeSession[] | null = null;
 let cacheTimestamp = 0;
@@ -890,10 +895,14 @@ export const detectActiveSessions = async (): Promise<ActiveSessionResult> => {
     // Primary: read ~/.claude/sessions/<PID>.json for direct PID → sessionId mapping.
     // These files are created on session start and deleted on session exit.
     // Claude Code also runs concurrentSessionCleanup() to remove stale files.
-    const sessionsDir = path.join(os.homedir(), '.claude', 'sessions');
-    if (fs.existsSync(sessionsDir)) {
+    const allSessions = readClaudeSessions(500);
+    // Multi-account: scan every configured account's sessions/ dir for PID files.
+    let anySessionsDir = false;
+    for (const account of getScannableAccounts()) {
+      const sessionsDir = path.join(account.dir, 'sessions');
+      if (!fs.existsSync(sessionsDir)) continue;
+      anySessionsDir = true;
       const files = fs.readdirSync(sessionsDir).filter(f => /^\d+\.json$/.test(f));
-      const allSessions = readClaudeSessions(500);
 
       for (const file of files) {
         try {
@@ -960,21 +969,21 @@ export const detectActiveSessions = async (): Promise<ActiveSessionResult> => {
           console.error(`[detect-active] Error processing session file ${file}:`, err);
         }
       }
-
-      // Read VS Code session JSONLs in parallel (head/tail)
-      if (vscodeReadPromises.length > 0) {
-        await Promise.all(vscodeReadPromises);
-      }
-
-      // Cross-reference for PIDs with same-cwd ambiguity.
-      // Group by terminal to avoid redundant pgrep/AppleScript/CLI calls.
-      if (needsCrossRef.length > 0) {
-        await crossRefDisambiguate(needsCrossRef, activeMap, execPromise);
-      }
     }
 
-    // Fallback: if sessions/ directory doesn't exist (old Claude Code versions)
-    if (!fs.existsSync(sessionsDir)) {
+    // Read VS Code session JSONLs in parallel (head/tail)
+    if (vscodeReadPromises.length > 0) {
+      await Promise.all(vscodeReadPromises);
+    }
+
+    // Cross-reference for PIDs with same-cwd ambiguity.
+    // Group by terminal to avoid redundant pgrep/AppleScript/CLI calls.
+    if (needsCrossRef.length > 0) {
+      await crossRefDisambiguate(needsCrossRef, activeMap, execPromise);
+    }
+
+    // Fallback: if no account had a sessions/ dir (old Claude Code versions)
+    if (!anySessionsDir) {
       await detectActiveSessionsLegacy(activeMap);
     }
   } catch (err) {
@@ -1131,7 +1140,7 @@ export const openSession = async (
  * real-time updates without duplicate file reads.
  */
 export const refreshSessionPreview = async (
-  sessions: { sessionId: string; project: string }[]
+  sessions: { sessionId: string; project: string; accountDir?: string }[]
 ): Promise<Map<string, { lastUserMessage: string; lastAssistantMessage: string }>> => {
   const { exec } = require('child_process');
   const execPromise = (cmd: string): Promise<string> =>
@@ -1142,11 +1151,13 @@ export const refreshSessionPreview = async (
     });
 
   const results = new Map<string, { lastUserMessage: string; lastAssistantMessage: string }>();
-  const claudeDir = path.join(os.homedir(), '.claude', 'projects');
-
   const promises = sessions.map(async (session) => {
     const encodedProject = session.project.replace(/[^a-zA-Z0-9-]/g, '-');
-    const jsonlPath = path.join(claudeDir, encodedProject, `${session.sessionId}.jsonl`);
+    const jsonlPath = path.join(
+      getProjectsDir(session.accountDir),
+      encodedProject,
+      `${session.sessionId}.jsonl`,
+    );
     if (!fs.existsSync(jsonlPath)) return;
 
     const output = await execPromise(`tail -n 100 "${jsonlPath}"`);
@@ -1606,11 +1617,13 @@ export const loadSessionEnrichment = async (sessions: ClaudeSession[]): Promise<
   const titles = new Map<string, string>();
   const branches = new Map<string, string>();
   const prLinks = new Map<string, PRLinkInfo>();
-  const claudeDir = path.join(os.homedir(), '.claude', 'projects');
-
   const promises = sessions.map(async (session) => {
     const encodedProject = session.project.replace(/[^a-zA-Z0-9-]/g, '-');
-    const jsonlPath = path.join(claudeDir, encodedProject, `${session.sessionId}.jsonl`);
+    const jsonlPath = path.join(
+      getProjectsDir(session.accountDir),
+      encodedProject,
+      `${session.sessionId}.jsonl`,
+    );
 
     if (!fs.existsSync(jsonlPath)) return;
 
@@ -1686,11 +1699,13 @@ export const loadLastAssistantResponses = async (
     });
 
   const responses = new Map<string, string>();
-  const claudeDir = path.join(os.homedir(), '.claude', 'projects');
-
   const promises = sessions.map(async (session) => {
     const encodedProject = session.project.replace(/[^a-zA-Z0-9-]/g, '-');
-    const jsonlPath = path.join(claudeDir, encodedProject, `${session.sessionId}.jsonl`);
+    const jsonlPath = path.join(
+      getProjectsDir(session.accountDir),
+      encodedProject,
+      `${session.sessionId}.jsonl`,
+    );
 
     if (!fs.existsSync(jsonlPath)) return;
 

--- a/src/claude-session-utility.ts
+++ b/src/claude-session-utility.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs';
 import { getCurrentIDEBundleId } from './vscode-based-ide-utility';
-import { getScannableAccounts } from './accounts';
+import { getScannableAccounts, getProjectsDir } from './accounts';
 
 export interface ClaudeSession {
   sessionId: string;
@@ -57,11 +57,6 @@ interface SessionAccum {
 const getHistoryPath = (dir: string): string => {
   return path.join(dir, 'history.jsonl');
 };
-
-// codev multi-account: a session's transcripts live under its account's config
-// dir. Falls back to ~/.claude for sessions without an account tag (e.g. VS Code).
-const getProjectsDir = (accountDir?: string): string =>
-  path.join(accountDir || path.join(os.homedir(), '.claude'), 'projects');
 
 // Cache for parsed sessions to avoid re-reading history.jsonl on every keystroke
 let cachedSessions: ClaudeSession[] | null = null;
@@ -1069,7 +1064,10 @@ const getResumeConfigDirEnv = (sessionId: string): string | null => {
  */
 const buildResumeCommand = (sessionId: string): string => {
   const configDir = getResumeConfigDirEnv(sessionId);
-  const prefix = configDir ? `CLAUDE_CONFIG_DIR="${configDir}" ` : '';
+  // Single-quote the value: some terminal injections (Ghostty `initial input`)
+  // don't escape the command, so a double-quoted prefix would break their
+  // AppleScript string. Single quotes are safe across all terminals + handle spaces.
+  const prefix = configDir ? `CLAUDE_CONFIG_DIR='${configDir}' ` : '';
   return `${prefix}claude --resume ${sessionId}`;
 };
 

--- a/src/claude-session-utility.ts
+++ b/src/claude-session-utility.ts
@@ -145,7 +145,10 @@ export const readClaudeSessions = (limit = 100): ClaudeSession[] => {
         }
       }
     } catch (error) {
-      console.error(`Error reading Claude sessions for ${account.label}:`, error);
+      console.error(
+        `Error reading Claude sessions for ${account.label}:`,
+        error,
+      );
     }
   }
 
@@ -296,7 +299,11 @@ end tell`);
     const candidates = allSessions.filter(s => s.project === cwd);
     const encodedProject = cwd.replace(/[^a-zA-Z0-9-]/g, '-');
     await Promise.all(candidates.map(async (session) => {
-      const jsonlPath = path.join(getProjectsDir(session.accountDir), encodedProject, `${session.sessionId}.jsonl`);
+      const jsonlPath = path.join(
+        getProjectsDir(session.accountDir),
+        encodedProject,
+        `${session.sessionId}.jsonl`,
+      );
       if (!fs.existsSync(jsonlPath)) return;
       const out = await execPromise(`grep '"type":"custom-title"' "${jsonlPath}" 2>/dev/null | tail -1`);
       try {
@@ -393,7 +400,11 @@ const refineDetectionWithCmux = async (
     const candidates = allSessions.filter(s => s.project === cwd);
     const encodedProject = cwd.replace(/[^a-zA-Z0-9-]/g, '-');
     await Promise.all(candidates.map(async (session) => {
-      const jsonlPath = path.join(getProjectsDir(session.accountDir), encodedProject, `${session.sessionId}.jsonl`);
+      const jsonlPath = path.join(
+        getProjectsDir(session.accountDir),
+        encodedProject,
+        `${session.sessionId}.jsonl`,
+      );
       if (!fs.existsSync(jsonlPath)) return;
       const out = await execPromise(`grep '"type":"custom-title"' "${jsonlPath}" 2>/dev/null | tail -1`);
       try {

--- a/src/claude-session-utility.ts
+++ b/src/claude-session-utility.ts
@@ -288,7 +288,6 @@ end tell`);
 
   // Cross-reference: for each iTerm2 claude PID, find its TTY → match iTerm2 tab → extract title → find session
   // Load custom titles lazily per-cwd to avoid scanning all sessions
-  const claudeDir = path.join(os.homedir(), '.claude', 'projects');
   const titleCache = new Map<string, Map<string, string>>(); // cwd → (sessionId → title)
 
   const getTitlesForCwd = async (cwd: string): Promise<Map<string, string>> => {
@@ -297,7 +296,7 @@ end tell`);
     const candidates = allSessions.filter(s => s.project === cwd);
     const encodedProject = cwd.replace(/[^a-zA-Z0-9-]/g, '-');
     await Promise.all(candidates.map(async (session) => {
-      const jsonlPath = path.join(claudeDir, encodedProject, `${session.sessionId}.jsonl`);
+      const jsonlPath = path.join(getProjectsDir(session.accountDir), encodedProject, `${session.sessionId}.jsonl`);
       if (!fs.existsSync(jsonlPath)) return;
       const out = await execPromise(`grep '"type":"custom-title"' "${jsonlPath}" 2>/dev/null | tail -1`);
       try {
@@ -386,7 +385,6 @@ const refineDetectionWithCmux = async (
   if (cmuxSurfaces.length === 0) return;
 
   // Load custom titles lazily per-cwd
-  const claudeDir = path.join(os.homedir(), '.claude', 'projects');
   const titleCache = new Map<string, Map<string, string>>();
 
   const getTitlesForCwd = async (cwd: string): Promise<Map<string, string>> => {
@@ -395,7 +393,7 @@ const refineDetectionWithCmux = async (
     const candidates = allSessions.filter(s => s.project === cwd);
     const encodedProject = cwd.replace(/[^a-zA-Z0-9-]/g, '-');
     await Promise.all(candidates.map(async (session) => {
-      const jsonlPath = path.join(claudeDir, encodedProject, `${session.sessionId}.jsonl`);
+      const jsonlPath = path.join(getProjectsDir(session.accountDir), encodedProject, `${session.sessionId}.jsonl`);
       if (!fs.existsSync(jsonlPath)) return;
       const out = await execPromise(`grep '"type":"custom-title"' "${jsonlPath}" 2>/dev/null | tail -1`);
       try {
@@ -461,24 +459,26 @@ const crossRefDisambiguate = async (
   }
 
   // Load custom titles lazily per-cwd (shared across terminals)
-  const claudeDir = path.join(os.homedir(), '.claude', 'projects');
   const titleCache = new Map<string, Map<string, string>>();
   const getTitlesForCwd = async (cwd: string): Promise<Map<string, string>> => {
     if (titleCache.has(cwd)) return titleCache.get(cwd)!;
     const titles = new Map<string, string>();
     const encodedProject = cwd.replace(/[^a-zA-Z0-9-]/g, '-');
-    const projectDir = path.join(claudeDir, encodedProject);
-    if (!fs.existsSync(projectDir)) { titleCache.set(cwd, titles); return titles; }
-    const jsonlFiles = fs.readdirSync(projectDir).filter(f => f.endsWith('.jsonl'));
-    await Promise.all(jsonlFiles.map(async (file) => {
-      const sessionId = file.replace('.jsonl', '');
-      const out = await execPromise(`grep '"type":"custom-title"' "${path.join(projectDir, file)}" 2>/dev/null | tail -1`);
-      try {
-        const parsed = JSON.parse(out.trim());
-        const title = (parsed.customTitle || '').replace(/^"|"$/g, '').trim();
-        if (title) titles.set(sessionId, title);
-      } catch {}
-    }));
+    // Scan every account's projects dir — the session may live under any account.
+    for (const account of getScannableAccounts()) {
+      const projectDir = path.join(getProjectsDir(account.dir), encodedProject);
+      if (!fs.existsSync(projectDir)) continue;
+      const jsonlFiles = fs.readdirSync(projectDir).filter(f => f.endsWith('.jsonl'));
+      await Promise.all(jsonlFiles.map(async (file) => {
+        const sessionId = file.replace('.jsonl', '');
+        const out = await execPromise(`grep '"type":"custom-title"' "${path.join(projectDir, file)}" 2>/dev/null | tail -1`);
+        try {
+          const parsed = JSON.parse(out.trim());
+          const title = (parsed.customTitle || '').replace(/^"|"$/g, '').trim();
+          if (title) titles.set(sessionId, title);
+        } catch {}
+      }));
+    }
     titleCache.set(cwd, titles);
     return titles;
   };

--- a/src/claude-session-utility.ts
+++ b/src/claude-session-utility.ts
@@ -8,6 +8,7 @@ import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs';
 import { getCurrentIDEBundleId } from './vscode-based-ide-utility';
+import { getScannableAccounts } from './accounts';
 
 export interface ClaudeSession {
   sessionId: string;
@@ -22,6 +23,9 @@ export interface ClaudeSession {
   activePid?: number;
   terminalApp?: string;    // detected terminal: 'iterm2', 'cmux', 'ghostty', 'vscode', etc.
   entrypoint?: string;     // 'cli', 'claude-vscode', etc.
+  accountLabel?: string; // codev multi-account: which account this session belongs to
+  accountDir?: string; // that account's config dir (session data + enrichment root)
+  accountIsDefault?: boolean; // default account => no CLAUDE_CONFIG_DIR at launch
 }
 
 export interface ActiveSessionResult {
@@ -45,10 +49,13 @@ interface SessionAccum {
   firstTimestamp: number;
   lastTimestamp: number;
   promptCount: number;
+  accountLabel: string;
+  accountDir: string;
+  accountIsDefault: boolean;
 }
 
-const getHistoryPath = (): string => {
-  return path.join(os.homedir(), '.claude', 'history.jsonl');
+const getHistoryPath = (dir: string): string => {
+  return path.join(dir, 'history.jsonl');
 };
 
 // Cache for parsed sessions to avoid re-reading history.jsonl on every keystroke
@@ -87,50 +94,55 @@ export const readClaudeSessions = (limit = 100): ClaudeSession[] => {
     return cachedSessions.slice(0, limit);
   }
 
-  const historyPath = getHistoryPath();
+  // Multi-account: scan every configured account's history.jsonl and merge.
+  // sessionIds are UUIDs (unique across accounts), so no cross-account dedupe.
+  const bySession = new Map<string, SessionAccum>();
 
   try {
-    if (!fs.existsSync(historyPath)) {
-      console.log('Claude history.jsonl not found:', historyPath);
-      return [];
-    }
+    for (const account of getScannableAccounts()) {
+      const historyPath = getHistoryPath(account.dir);
+      if (!fs.existsSync(historyPath)) continue;
 
-    const content = fs.readFileSync(historyPath, 'utf-8');
-    const bySession = new Map<string, SessionAccum>();
+      const content = fs.readFileSync(historyPath, 'utf-8');
+      for (const line of content.split('\n')) {
+        if (!line.trim()) continue;
+        try {
+          const raw: HistoryLine = JSON.parse(line);
+          if (!raw.sessionId) continue;
 
-    for (const line of content.split('\n')) {
-      if (!line.trim()) continue;
-      try {
-        const raw: HistoryLine = JSON.parse(line);
-        if (!raw.sessionId) continue;
-
-        const existing = bySession.get(raw.sessionId);
-        if (existing) {
-          existing.promptCount++;
-          if (raw.timestamp && raw.timestamp > existing.lastTimestamp) {
-            existing.lastTimestamp = raw.timestamp;
-            existing.lastDisplay = raw.display || existing.lastDisplay;
+          const existing = bySession.get(raw.sessionId);
+          if (existing) {
+            existing.promptCount++;
+            if (raw.timestamp && raw.timestamp > existing.lastTimestamp) {
+              existing.lastTimestamp = raw.timestamp;
+              existing.lastDisplay = raw.display || existing.lastDisplay;
+            }
+            if (raw.timestamp && raw.timestamp < existing.firstTimestamp) {
+              existing.firstDisplay = raw.display || existing.firstDisplay;
+              existing.firstTimestamp = raw.timestamp;
+            }
+          } else {
+            bySession.set(raw.sessionId, {
+              sessionId: raw.sessionId,
+              project: raw.project || '',
+              firstDisplay: raw.display || '',
+              lastDisplay: raw.display || '',
+              firstTimestamp: raw.timestamp || 0,
+              lastTimestamp: raw.timestamp || 0,
+              promptCount: 1,
+              accountLabel: account.label,
+              accountDir: account.dir,
+              accountIsDefault: account.isDefault,
+            });
           }
-          if (raw.timestamp && raw.timestamp < existing.firstTimestamp) {
-            existing.firstDisplay = raw.display || existing.firstDisplay;
-            existing.firstTimestamp = raw.timestamp;
-          }
-        } else {
-          bySession.set(raw.sessionId, {
-            sessionId: raw.sessionId,
-            project: raw.project || '',
-            firstDisplay: raw.display || '',
-            lastDisplay: raw.display || '',
-            firstTimestamp: raw.timestamp || 0,
-            lastTimestamp: raw.timestamp || 0,
-            promptCount: 1,
-          });
+        } catch {
+          // skip malformed lines
         }
-      } catch {
-        // skip malformed lines
       }
     }
 
+    // Unified timeline: sort the MERGED set by recency (newest first) so both
+    // accounts interleave by lastTimestamp. The account badge disambiguates.
     const allSessions = Array.from(bySession.values())
       .sort((a, b) => b.lastTimestamp - a.lastTimestamp)
       .map((s) => ({
@@ -142,6 +154,9 @@ export const readClaudeSessions = (limit = 100): ClaudeSession[] => {
         lastTimestamp: s.lastTimestamp,
         messageCount: s.promptCount,
         isActive: false,
+        accountLabel: s.accountLabel,
+        accountDir: s.accountDir,
+        accountIsDefault: s.accountIsDefault,
       }));
 
     cachedSessions = allSessions;
@@ -1028,6 +1043,28 @@ const detectActiveSessionsLegacy = async (activeMap: Map<string, number>): Promi
 };
 
 /**
+ * codev multi-account: look up which account a session belongs to (via the
+ * cached session list, which tags each session with its config dir) and return
+ * the CLAUDE_CONFIG_DIR to prefix at resume — or null for the default account.
+ */
+const getResumeConfigDirEnv = (sessionId: string): string | null => {
+  const s = readClaudeSessions(Number.MAX_SAFE_INTEGER).find(
+    (x) => x.sessionId === sessionId,
+  );
+  return s && !s.accountIsDefault && s.accountDir ? s.accountDir : null;
+};
+
+/**
+ * Build `claude --resume <id>`, prefixed with CLAUDE_CONFIG_DIR when the session
+ * belongs to a non-default account so it resumes under the right account.
+ */
+const buildResumeCommand = (sessionId: string): string => {
+  const configDir = getResumeConfigDirEnv(sessionId);
+  const prefix = configDir ? `CLAUDE_CONFIG_DIR="${configDir}" ` : '';
+  return `${prefix}claude --resume ${sessionId}`;
+};
+
+/**
  * Open a Claude Code session in the configured terminal.
  */
 export const openSession = async (
@@ -1527,7 +1564,7 @@ end tell`;
       try { fs.unlinkSync(tmpScript); } catch {}
     });
   } else {
-    const resumeCmd = `claude --resume ${sessionId}`;
+    const resumeCmd = buildResumeCommand(sessionId);
     runCommandInTerminal(`cd "${projectPath}" && ${resumeCmd}`, resumeCmd, projectPath, 'iterm2', terminalMode);
   }
 };
@@ -1742,7 +1779,7 @@ end tell`;
       try { fs.unlinkSync(tmpScript); } catch {}
     });
   } else {
-    const resumeCmd = `claude --resume ${sessionId}`;
+    const resumeCmd = buildResumeCommand(sessionId);
     runCommandInTerminal(`cd "${projectPath}" && ${resumeCmd}`, resumeCmd, projectPath, 'ghostty', terminalMode);
   }
 };
@@ -1804,7 +1841,7 @@ end tell`;
       try { fs.unlinkSync(tmpScript); } catch {}
     });
   } else {
-    const resumeCmd = `claude --resume ${sessionId}`;
+    const resumeCmd = buildResumeCommand(sessionId);
     runCommandInTerminal(`cd "${projectPath}" && ${resumeCmd}`, resumeCmd, projectPath, 'terminal', terminalMode);
   }
 };
@@ -1824,7 +1861,7 @@ export const openSessionInCmux = (
   customTitle?: string,
 ): void => {
   const { exec } = require('child_process');
-  const command = `cd "${projectPath}" && claude --resume ${sessionId}`;
+  const command = `cd "${projectPath}" && ${buildResumeCommand(sessionId)}`;
 
   console.log('[cmux] openSession:', { sessionId, projectPath, isActive, activePid, customTitle });
   if (isActive) {
@@ -1949,7 +1986,7 @@ export const openSessionInCmux = (
       exec('osascript -e \'tell application "cmux" to activate\'');
     })();
   } else {
-    const resumeCmd = `claude --resume ${sessionId}`;
+    const resumeCmd = buildResumeCommand(sessionId);
     runCommandInTerminal(`cd "${projectPath}" && ${resumeCmd}`, resumeCmd, projectPath, 'cmux');
   }
 };
@@ -1958,7 +1995,7 @@ export const openSessionInCmux = (
  * Copy resume command to clipboard (fallback for unsupported terminals)
  */
 export const copyResumeCommand = (sessionId: string, projectPath: string): string => {
-  const command = `cd "${projectPath}" && claude --resume ${sessionId}`;
+  const command = `cd "${projectPath}" && ${buildResumeCommand(sessionId)}`;
   const { execSync } = require('child_process');
   execSync(`echo "${command}" | pbcopy`);
   return command;

--- a/src/main.ts
+++ b/src/main.ts
@@ -2002,9 +2002,19 @@ ipcMain.handle('get-session-statuses', async () => {
         if (!session && isDebug) {
           console.log(`[session-status] active session ${sessionId} not found in allKnown (${allKnown.length} sessions)`);
         }
-        return session ? { sessionId, project: session.project, accountDir: session.accountDir } : null;
+        return session
+          ? {
+              sessionId,
+              project: session.project,
+              accountDir: session.accountDir,
+            }
+          : null;
       })
-      .filter(Boolean) as { sessionId: string; project: string; accountDir?: string }[];
+      .filter(Boolean) as {
+      sessionId: string;
+      project: string;
+      accountDir?: string;
+    }[];
 
     if (sessionsWithoutStatus.length > 0) {
       if (isDebug) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2002,9 +2002,9 @@ ipcMain.handle('get-session-statuses', async () => {
         if (!session && isDebug) {
           console.log(`[session-status] active session ${sessionId} not found in allKnown (${allKnown.length} sessions)`);
         }
-        return session ? { sessionId, project: session.project } : null;
+        return session ? { sessionId, project: session.project, accountDir: session.accountDir } : null;
       })
-      .filter(Boolean) as { sessionId: string; project: string }[];
+      .filter(Boolean) as { sessionId: string; project: string; accountDir?: string }[];
 
     if (sessionsWithoutStatus.length > 0) {
       if (isDebug) {

--- a/src/session-status-hooks.ts
+++ b/src/session-status-hooks.ts
@@ -8,6 +8,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import { getScannableAccounts } from './accounts';
 
 const CLAUDE_DIR = path.join(os.homedir(), '.claude');
 const SETTINGS_PATH = path.join(CLAUDE_DIR, 'settings.json');
@@ -68,24 +69,32 @@ mv -f "$TMPFILE" "$STATUS_DIR/$SESSION_ID.json"
 `;
 
 /**
- * Install hooks into ~/.claude/settings.json (idempotent, merges with existing)
+ * All accounts' settings.json paths. The hook script + status dir stay at
+ * ~/.claude (fixed — the script always writes to ~/.claude/codev-status), but
+ * the hook must be REGISTERED in each account's settings.json so status fires
+ * for sessions running under any account.
  */
-export const installHooks = (): void => {
-  // Create hook script
-  fs.mkdirSync(path.dirname(HOOK_SCRIPT_PATH), { recursive: true });
-  fs.writeFileSync(HOOK_SCRIPT_PATH, HOOK_SCRIPT, { mode: 0o755 });
+const getSettingsPaths = (): string[] =>
+  getScannableAccounts().map((a) => path.join(a.dir, 'settings.json'));
 
-  // Create status directory
-  fs.mkdirSync(STATUS_DIR, { recursive: true });
+/** Back up a settings.json before we modify it. */
+const backupSettings = (settingsPath: string): void => {
+  try {
+    if (fs.existsSync(settingsPath)) {
+      fs.copyFileSync(settingsPath, `${settingsPath}.codev-bak`);
+    }
+  } catch {}
+};
 
+/** Merge our hook into one account's settings.json (idempotent). */
+const installHookIntoSettings = (settingsPath: string): void => {
   // Read existing settings — abort if file exists but can't be parsed (don't overwrite)
   let settings: any = {};
   try {
-    if (fs.existsSync(SETTINGS_PATH)) {
-      settings = JSON.parse(fs.readFileSync(SETTINGS_PATH, 'utf-8'));
+    if (fs.existsSync(settingsPath)) {
+      settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
     }
   } catch {
-    // Can't parse existing file — don't risk overwriting user's settings
     return;
   }
 
@@ -111,31 +120,31 @@ export const installHooks = (): void => {
   }
 
   if (modified) {
-    fs.writeFileSync(SETTINGS_PATH, JSON.stringify(settings, null, 2), 'utf-8');
+    backupSettings(settingsPath);
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2), 'utf-8');
   }
 };
 
 /**
- * Remove our hooks from ~/.claude/settings.json
+ * Install hooks into every configured account's settings.json (idempotent).
+ * The hook script + status dir are shared at ~/.claude.
  */
-export const removeHooks = (): void => {
-  // Remove hook script
-  try { fs.unlinkSync(HOOK_SCRIPT_PATH); } catch {}
+export const installHooks = (): void => {
+  fs.mkdirSync(path.dirname(HOOK_SCRIPT_PATH), { recursive: true });
+  fs.writeFileSync(HOOK_SCRIPT_PATH, HOOK_SCRIPT, { mode: 0o755 });
+  fs.mkdirSync(STATUS_DIR, { recursive: true });
 
-  // Remove status files
-  try {
-    if (fs.existsSync(STATUS_DIR)) {
-      for (const f of fs.readdirSync(STATUS_DIR)) {
-        fs.unlinkSync(path.join(STATUS_DIR, f));
-      }
-      fs.rmdirSync(STATUS_DIR);
-    }
-  } catch {}
+  for (const settingsPath of getSettingsPaths()) {
+    installHookIntoSettings(settingsPath);
+  }
+};
 
-  // Remove our entries from settings.json
+/** Remove our hook from one account's settings.json. */
+const removeHookFromSettings = (settingsPath: string): void => {
   try {
-    if (!fs.existsSync(SETTINGS_PATH)) return;
-    const settings = JSON.parse(fs.readFileSync(SETTINGS_PATH, 'utf-8'));
+    if (!fs.existsSync(settingsPath)) return;
+    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
     if (!settings.hooks) return;
 
     let modified = false;
@@ -156,9 +165,31 @@ export const removeHooks = (): void => {
     }
 
     if (modified) {
-      fs.writeFileSync(SETTINGS_PATH, JSON.stringify(settings, null, 2), 'utf-8');
+      backupSettings(settingsPath);
+      fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2), 'utf-8');
     }
   } catch {}
+};
+
+/**
+ * Remove our hooks from every account's settings.json + delete the shared
+ * hook script and status dir.
+ */
+export const removeHooks = (): void => {
+  try { fs.unlinkSync(HOOK_SCRIPT_PATH); } catch {}
+
+  try {
+    if (fs.existsSync(STATUS_DIR)) {
+      for (const f of fs.readdirSync(STATUS_DIR)) {
+        fs.unlinkSync(path.join(STATUS_DIR, f));
+      }
+      fs.rmdirSync(STATUS_DIR);
+    }
+  } catch {}
+
+  for (const settingsPath of getSettingsPaths()) {
+    removeHookFromSettings(settingsPath);
+  }
 };
 
 /**

--- a/src/session-status-hooks.ts
+++ b/src/session-status-hooks.ts
@@ -323,7 +323,11 @@ export const scanInitialStatuses = async (
 
     // Find JSONL file
     const encodedProject = session.project.replace(/[^a-zA-Z0-9-]/g, '-');
-    const jsonlPath = path.join(getProjectsDir(session.accountDir), encodedProject, `${session.sessionId}.jsonl`);
+    const jsonlPath = path.join(
+      getProjectsDir(session.accountDir),
+      encodedProject,
+      `${session.sessionId}.jsonl`,
+    );
     if (!fs.existsSync(jsonlPath)) return;
 
     // Read last 15 lines

--- a/src/session-status-hooks.ts
+++ b/src/session-status-hooks.ts
@@ -8,7 +8,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { getScannableAccounts } from './accounts';
+import { getScannableAccounts, getProjectsDir } from './accounts';
 
 const CLAUDE_DIR = path.join(os.homedir(), '.claude');
 const SETTINGS_PATH = path.join(CLAUDE_DIR, 'settings.json');
@@ -296,7 +296,7 @@ export const watchStatusDir = (
  * - Otherwise → working
  */
 export const scanInitialStatuses = async (
-  activeSessions: { sessionId: string; project: string }[],
+  activeSessions: { sessionId: string; project: string; accountDir?: string }[],
 ): Promise<Map<string, SessionStatus>> => {
   const { execFile } = require('child_process');
   const tailFile = (filePath: string): Promise<string> =>
@@ -311,7 +311,6 @@ export const scanInitialStatuses = async (
     });
 
   const statuses = new Map<string, SessionStatus>();
-  const claudeDir = path.join(os.homedir(), '.claude', 'projects');
 
   const startTime = Date.now();
 
@@ -322,7 +321,7 @@ export const scanInitialStatuses = async (
 
     // Find JSONL file
     const encodedProject = session.project.replace(/[^a-zA-Z0-9-]/g, '-');
-    const jsonlPath = path.join(claudeDir, encodedProject, `${session.sessionId}.jsonl`);
+    const jsonlPath = path.join(getProjectsDir(session.accountDir), encodedProject, `${session.sessionId}.jsonl`);
     if (!fs.existsSync(jsonlPath)) return;
 
     // Read last 15 lines

--- a/src/session-status-hooks.ts
+++ b/src/session-status-hooks.ts
@@ -11,7 +11,6 @@ import * as os from 'os';
 import { getScannableAccounts, getProjectsDir } from './accounts';
 
 const CLAUDE_DIR = path.join(os.homedir(), '.claude');
-const SETTINGS_PATH = path.join(CLAUDE_DIR, 'settings.json');
 const STATUS_DIR = path.join(CLAUDE_DIR, 'codev-status');
 const HOOK_SCRIPT_PATH = path.join(CLAUDE_DIR, 'codev-status-hook.sh');
 const HOOK_MARKER = 'codev-status-hook';
@@ -83,7 +82,9 @@ const backupSettings = (settingsPath: string): void => {
     if (fs.existsSync(settingsPath)) {
       fs.copyFileSync(settingsPath, `${settingsPath}.codev-bak`);
     }
-  } catch {}
+  } catch {
+    // best-effort backup
+  }
 };
 
 /** Merge our hook into one account's settings.json (idempotent). */
@@ -196,20 +197,21 @@ export const removeHooks = (): void => {
  * Check if our hooks are currently installed
  */
 export const isHooksInstalled = (): boolean => {
-  try {
-    if (!fs.existsSync(SETTINGS_PATH)) return false;
-    const settings = JSON.parse(fs.readFileSync(SETTINGS_PATH, 'utf-8'));
-    if (!settings.hooks) return false;
-
-    // Check if at least one of our events has our hook
-    return HOOK_EVENTS.some(event =>
-      settings.hooks[event]?.some((entry: any) =>
-        entry.hooks?.some((h: any) => h.command === HOOK_SCRIPT_PATH)
-      )
-    );
-  } catch {
-    return false;
-  }
+  // Consistent with multi-account install/remove: installed if any account's
+  // settings.json has our hook.
+  return getSettingsPaths().some((settingsPath) => {
+    try {
+      if (!fs.existsSync(settingsPath)) return false;
+      const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+      return HOOK_EVENTS.some((event) =>
+        settings.hooks?.[event]?.some((entry: any) =>
+          entry.hooks?.some((h: any) => h.command === HOOK_SCRIPT_PATH),
+        ),
+      );
+    } catch {
+      return false;
+    }
+  });
 };
 
 export type SessionStatus = 'working' | 'idle' | 'needs-attention' | 'unknown' | null;

--- a/src/switcher-ui.tsx
+++ b/src/switcher-ui.tsx
@@ -1324,6 +1324,21 @@ function SwitcherApp() {
                             </span>
                           );
                         })()}
+                        {session.accountLabel && !session.accountIsDefault && (
+                          <span
+                            style={{
+                              fontSize: '9px',
+                              color: '#c9a0e8',
+                              border: '1px solid #7a5a9e',
+                              borderRadius: '3px',
+                              padding: '1px 4px',
+                              textTransform: 'uppercase',
+                            }}
+                            title={`Claude account: ${session.accountLabel}`}
+                          >
+                            {session.accountLabel}
+                          </span>
+                        )}
                         {(() => {
                           // Only show terminal/IDE badge for active sessions
                           const badge = session.isActive


### PR DESCRIPTION
Run multiple Claude Code accounts (e.g. personal + work) from one machine. Built on the verified fact that `CLAUDE_CONFIG_DIR` fully isolates a Claude Code account on macOS (`docs/multi-account-support-design.md` §3).

## What it does

- **CLI** (via `~/.config/codev/accounts.sh`, sourced from your shell rc): `claude <account>` / `claude-<account>` launch the official `claude` under that account's `CLAUDE_CONFIG_DIR`; bare `claude` stays the default account; `claude-whoami` / `claude-accounts` inspect. All native flags pass through.
- **CodeV Sessions tab**: reads every configured account's config dir (not just `~/.claude`) and merges into one recency-sorted list; badges non-default accounts (`WORK`); resumes each session under its own account; per-account active dots, custom titles/branches, and previews; registers status hooks in each account's `settings.json`.

## Is it fully functional?

- **Multi-account**: yes — once the registry (`~/.config/codev/accounts.json`) + `accounts.sh` are set up and the extra account is logged in. Validated end-to-end (list, `WORK` badge, account-aware resume, active dots, titles) via `yarn make`.
- **If you do nothing / single account**: **CodeV behaves exactly as before.** `getAccounts()` falls back to a single default account when there's no registry, so the feature is entirely opt-in and invisible to single-account users — all pre-PR functionality is preserved.

## ⚠️ Setup is manual for now (Batch 1)

Account setup (the `~/.config/codev/accounts.json` registry + `~/.config/codev/accounts.sh`) is **hand-created** in this batch — CodeV *reads* the registry but doesn't yet *generate* it. A point-and-click **management UI + `codev account` CLI** is planned (Batch 2). See design doc §11 "How to use it now".

## CodeV never touches tokens

CodeV only ever sets `CLAUDE_CONFIG_DIR` and launches the official `claude` binary — it never reads OAuth tokens, calls the model, or embeds an agent. This keeps it inside Anthropic's "use the official product" terms (design doc §2).

## Commits

- `ee4a546` design doc + registry reader (`src/accounts.ts`)
- `57f609b` session aggregation + badge + account-aware resume
- `5f05d9a` active dots + enrichment per account
- `46c49d1` status hooks per account
- `5cb3c1a` same-cwd cross-ref per account
- `9b45dc7` docs + changelog + version bump (1.0.76)

## Caller audit (per shared-change guidance)

`src/accounts.ts` is a new util (no existing callers). The session-reading changes tag each session with its account; the enrichment/preview/hook callers (`main.ts` IPC handlers, `switcher-ui.tsx`) pass full session objects, so `accountDir` flows through (verified). Graceful fallback to `~/.claude` when a session has no account tag (e.g. VS Code).

## Deferred

- VS Code (`claude-vscode`) sessions can't be account-switched (URI-handler launch) — #121
- Batch 2: management UI + `codev account` CLI, per-launch account picker, configurable global-default (`nvm alias default`-style), pyenv-style folder auto-switch
- Batch 3: cross-account symlink reuse of global `CLAUDE.md` / skills

## Testing

- `tsc --noEmit` clean throughout; each commit is a minimal, focused diff.
- User-validated (personal + work): session list, `WORK` badge, account-aware resume, active dots, titles — all correct after `yarn make`.

🤖 On behalf of @grimmerk — generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add multi-account support so you can run multiple Claude Code accounts on one machine. CodeV now merges sessions across accounts and resumes each under the correct account using the registry’s `configDirEnv`; setup is manual (`accounts.json` + `accounts.sh`), and single-account users see no change.

- **New Features**
  - Sessions tab reads all configured account dirs and shows one recency-sorted list with a badge for non-default accounts; resume/new launches inject `CLAUDE_CONFIG_DIR` for the right account (VS Code unchanged).
  - Per-account active dots, custom titles/branches, and previews; status hooks are installed in each account’s `settings.json` and write to a shared status dir.
  - Registry reader for `~/.config/codev/accounts.json` with default fallback; optional CLI helpers via a sourced `~/.config/codev/accounts.sh` (`claude <account>`, `claude-<account>`, `claude-whoami`, `claude-accounts`). Docs include a copy-paste example.

- **Bug Fixes**
  - Ghostty resume: single-quoted `CLAUDE_CONFIG_DIR` prefix to avoid breaking its AppleScript string.
  - Initial status: reads each session’s own account dir, fixing stuck purple dots for non-default accounts.
  - Robustness/correctness: resume uses the registry’s `configDirEnv` (not the scan dir); per-account history reads are isolated; hook install detection checks all accounts; clipboard copy uses `pbcopy` via `execFileSync`; accounts infer `isDefault` from `defaultAccount`.
  - Formatting: wrapped long lines flagged in review (no behavior changes).

<sup>Written for commit b3ba3fb596fd5bfa1f683d1cca28c76a0a08a4ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/grimmerk/codev/pull/122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-account support with unified session discovery across accounts and account-specific badges in the Sessions list.
  * Updated resume commands to reopen sessions in the correct account context (non-default accounts only); note: VS Code sessions can’t switch accounts.
  * Extended status hook installation so it’s managed per configured account.
* **Documentation**
  * Added multi-account support design documentation and updated the changelog for version 1.0.76.
* **Chores**
  * Bumped the application version to 1.0.76.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## Follow-up (post-open fixes)

Found while testing non-default (work) account sessions:

- **Ghostty resume fix** (`7b9705e`): the injected `CLAUDE_CONFIG_DIR` prefix was double-quoted, which broke Ghostty's unescaped `initial input:"..."` AppleScript string — non-default accounts couldn't resume in Ghostty (iTerm2/Terminal/cmux were fine). Now single-quoted (safe across all terminals).
- **Purple-dot fix** (`7b9705e`): work sessions stayed on the "active-unknown" purple dot after resume because `scanInitialStatuses` read `~/.claude/projects` for every session, so a work session's JSONL wasn't found. Now reads each session's own account dir (`getProjectsDir` moved to `accounts.ts`; `accountDir` threaded through `get-session-statuses`).
- **Docs** (`ca8f0be`): §11 "How to use it now" now has a copy-paste-ready `accounts.json` + `accounts.sh` example.

**Minor perf note (non-blocking):** `getResumeConfigDirEnv` calls `readClaudeSessions(Number.MAX_SAFE_INTEGER)`, which copies the full session array before `.find()` — O(n) per resume click, n≈hundreds, negligible; can later be changed to query the cache directly.

