### PR TITLE
feat(multi-account): Accounts tab in Settings (Batch 2b part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.0.78
+
+- Feat: multi-account Batch 2b (part 1) — Accounts tab in Settings
+  - List accounts (identity, default marker), add (with log-in hint), remove, and set the global default — via IPC over the same shared generator the `codev account` CLI uses
+  - Shell-integration install/uninstall (`~/.zshrc` source block) from the UI
+  - Remaining 2b item: a real `codev` binary on PATH
+
 ## 1.0.77
 
 - Feat: multi-account Batch 2a + 2e — `codev account` CLI + configurable global-default

--- a/docs/multi-account-support-design.md
+++ b/docs/multi-account-support-design.md
@@ -433,8 +433,10 @@ and **(d)** for CodeV, backed by the same `projectMap` in the registry so both a
 - **Batch 2 — in progress (order 2a→2e):**
   - *2a — ✅ Done* (branch `feat/codev-account-cli`): `codev account` CLI generates the
     registry + `accounts.sh` from one shared generator (§6.A/B); Vitest + CI added.
-  - *2b:* manage-accounts Settings tab — list/add/rename/remove + shell-integration
-    toggle (§6.D), plus a real `codev` binary on PATH.
+  - *2b (UI ✅, branch `feat/accounts-settings-ui`):* Accounts tab in Settings —
+    list/add/remove + set-default + shell-integration toggle (§6.D), as IPC wrappers
+    over the shared manager (one generator with the CLI). Rename deferred (labels name
+    dirs; remove+add covers it). Remaining 2b item: a real `codev` binary on PATH.
   - *2c:* account picker / per-launch override (§6.G, 4.2).
   - *2d:* pyenv-style folder auto-switch + terminal-side resume-to-right-account (§6.H).
   - *2e:* configurable global-default (bare `claude` → chosen account) — last, since it

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "CodeV",
   "productName": "CodeV",
-  "version": "1.0.77",
+  "version": "1.0.78",
   "description": "Quick switcher for VS Code, Cursor, and Claude Code sessions",
   "repository": {
     "type": "git",

--- a/src/cli/account-manager.ts
+++ b/src/cli/account-manager.ts
@@ -319,6 +319,23 @@ export function addAccount(
   );
   assertSafeDir(dir);
   const isDefault = isDefaultDir(dir);
+  // Fresh registry + adding an EXTRA account: seed the anchor (~/.claude)
+  // account first, so the machine's existing default install stays registered
+  // and keeps the global default (instead of it silently moving to a
+  // brand-new, not-yet-logged-in account).
+  if (reg.accounts.length === 0 && !isDefault) {
+    const anchorLabel = label === 'personal' ? 'default' : 'personal';
+    const anchorIdentity = path.join(os.homedir(), '.claude.json');
+    reg.accounts.push({
+      label: anchorLabel,
+      dir: defaultDir(),
+      identityFile: anchorIdentity,
+      configDirEnv: null,
+      isDefault: true,
+      ...readIdentity(anchorIdentity),
+    });
+    reg.defaultAccount = anchorLabel;
+  }
   const identityFile = isDefault
     ? path.join(os.homedir(), '.claude.json')
     : path.join(dir, '.claude.json');

--- a/src/electron-api.d.ts
+++ b/src/electron-api.d.ts
@@ -2,9 +2,40 @@
 
 type IpcCallback = (event: Electron.IpcRendererEvent, ...args: any[]) => void;
 
+/** One configured Claude Code account (codev multi-account). */
+interface CodevAccountInfo {
+  label: string;
+  dir: string;
+  isDefault: boolean; // the anchor ~/.claude account
+  isCurrentDefault: boolean; // what bare `claude` resolves to
+  email?: string;
+  org?: string;
+  loggedIn?: boolean;
+}
+
 interface IElectronAPI {
   // App actions
   getHomeDir: () => Promise<string>;
+  // codev multi-account (Settings → Accounts)
+  getAccounts: () => Promise<{
+    ok: boolean;
+    error?: string;
+    accounts?: CodevAccountInfo[];
+    shellInstalled?: boolean;
+  }>;
+  addAccount: (label: string) => Promise<{
+    ok: boolean;
+    error?: string;
+    account?: CodevAccountInfo;
+  }>;
+  removeAccount: (label: string) => Promise<{ ok: boolean; error?: string }>;
+  setDefaultAccount: (label: string) => Promise<{ ok: boolean; error?: string }>;
+  setAccountsShellHook: (action: 'install' | 'uninstall') => Promise<{
+    ok: boolean;
+    error?: string;
+    changed?: boolean;
+    path?: string;
+  }>;
   getBannerSeen: () => Promise<boolean>;
   setBannerSeen: () => void;
   invokeVSCode: (path: string, option: string) => void;

--- a/src/main.ts
+++ b/src/main.ts
@@ -644,8 +644,13 @@ ipcMain.handle('accounts-get', () => {
 
 ipcMain.handle('accounts-add', (_event, label: string) => {
   try {
-    const account = accountManager.addAccount(label);
+    const added = accountManager.addAccount(label);
     invalidateAccountsCache();
+    // Return the enriched (listed) shape so it matches CodevAccountInfo
+    // (isCurrentDefault etc.), not the raw registry entry.
+    const account =
+      accountManager.listAccounts().find((a) => a.label === added.label) ||
+      added;
     return { ok: true, account };
   } catch (error) {
     return { ok: false, error: (error as Error).message };
@@ -676,6 +681,13 @@ ipcMain.handle(
   'accounts-shell-hook',
   (_event, action: 'install' | 'uninstall') => {
     try {
+      // Validate: a malformed payload must fail, not silently uninstall.
+      if (action !== 'install' && action !== 'uninstall') {
+        return {
+          ok: false,
+          error: `Unknown shell-hook action "${String(action)}"`,
+        };
+      }
       const result =
         action === 'install'
           ? accountManager.installShellHook()

--- a/src/main.ts
+++ b/src/main.ts
@@ -647,10 +647,16 @@ ipcMain.handle('accounts-add', (_event, label: string) => {
     const added = accountManager.addAccount(label);
     invalidateAccountsCache();
     // Return the enriched (listed) shape so it matches CodevAccountInfo
-    // (isCurrentDefault etc.), not the raw registry entry.
-    const account =
-      accountManager.listAccounts().find((a) => a.label === added.label) ||
-      added;
+    // (isCurrentDefault etc.), not the raw registry entry. The fallback
+    // derives isCurrentDefault too, keeping the IPC contract intact.
+    const account = accountManager
+      .listAccounts()
+      .find((a) => a.label === added.label) || {
+      ...added,
+      isCurrentDefault:
+        accountManager.resolveDefaultLabel(accountManager.readRegistry()) ===
+        added.label,
+    };
     return { ok: true, account };
   } catch (error) {
     return { ok: false, error: (error as Error).message };

--- a/src/main.ts
+++ b/src/main.ts
@@ -43,6 +43,8 @@ import {
   readVSCodeIndex,
   SessionStatus,
 } from './session-status-hooks';
+import * as accountManager from './cli/account-manager';
+import { invalidateAccountsCache } from './accounts';
 import {
   deleteRecentProjectRecord,
   openVSCodeBasedIDE,
@@ -624,6 +626,66 @@ ipcMain.on('search-working-folder', (event, path: string) => {
 ipcMain.handle('get-home-dir', () => {
   return require('os').homedir();
 });
+
+// --- codev multi-account management (Settings → Accounts, Batch 2b) ---
+// Thin IPC wrappers over the shared manager (src/cli/account-manager.ts),
+// the same module the `codev account` CLI uses — one generator, no drift.
+ipcMain.handle('accounts-get', () => {
+  try {
+    return {
+      ok: true,
+      accounts: accountManager.listAccounts(),
+      shellInstalled: accountManager.isShellHookInstalled(),
+    };
+  } catch (error) {
+    return { ok: false, error: (error as Error).message };
+  }
+});
+
+ipcMain.handle('accounts-add', (_event, label: string) => {
+  try {
+    const account = accountManager.addAccount(label);
+    invalidateAccountsCache();
+    return { ok: true, account };
+  } catch (error) {
+    return { ok: false, error: (error as Error).message };
+  }
+});
+
+ipcMain.handle('accounts-remove', (_event, label: string) => {
+  try {
+    accountManager.removeAccount(label);
+    invalidateAccountsCache();
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error: (error as Error).message };
+  }
+});
+
+ipcMain.handle('accounts-set-default', (_event, label: string) => {
+  try {
+    accountManager.setDefault(label);
+    invalidateAccountsCache();
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error: (error as Error).message };
+  }
+});
+
+ipcMain.handle(
+  'accounts-shell-hook',
+  (_event, action: 'install' | 'uninstall') => {
+    try {
+      const result =
+        action === 'install'
+          ? accountManager.installShellHook()
+          : accountManager.uninstallShellHook();
+      return { ok: true, changed: result.changed, path: result.path };
+    } catch (error) {
+      return { ok: false, error: (error as Error).message };
+    }
+  },
+);
 
 ipcMain.on('hide-app', (event) => {
   hideSwitcherWindow();

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -108,84 +108,117 @@ const PopupDefaultExample = ({
   const [accountsError, setAccountsError] = useState('');
   const [accountsNotice, setAccountsNotice] = useState('');
   const [newAccountLabel, setNewAccountLabel] = useState('');
+  const [accountsBusy, setAccountsBusy] = useState(false);
 
-  const refreshAccounts = () => {
-    window.electronAPI.getAccounts().then((r) => {
+  const refreshAccounts = async () => {
+    try {
+      const r = await window.electronAPI.getAccounts();
       if (r.ok) {
         setAccounts((r.accounts as AccountRow[]) || []);
         setAccountsShellInstalled(!!r.shellInstalled);
+        setAccountsError('');
       } else {
+        setAccountsNotice('');
         setAccountsError(r.error || 'Failed to load accounts');
       }
-    });
+    } catch (e) {
+      setAccountsNotice('');
+      setAccountsError((e as Error).message || 'Failed to load accounts');
+    }
   };
 
   useEffect(() => {
     if (isOpen && settingsTab === 'accounts') {
+      // Fresh view: drop any stale notice/error from a previous visit.
+      setAccountsError('');
+      setAccountsNotice('');
       refreshAccounts();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, settingsTab]);
 
-  const handleAddAccount = async () => {
+  /** Serialize account mutations: busy-guard + shared error handling. */
+  const runAccountOp = async (op: () => Promise<void>) => {
+    if (accountsBusy) return;
+    setAccountsBusy(true);
+    setAccountsError('');
+    try {
+      await op();
+    } catch (e) {
+      setAccountsNotice('');
+      setAccountsError((e as Error).message || 'Account operation failed');
+    } finally {
+      setAccountsBusy(false);
+    }
+  };
+
+  const handleAddAccount = () => {
     const label = newAccountLabel.trim();
     if (!label) return;
-    setAccountsError('');
-    const r = await window.electronAPI.addAccount(label);
-    if (r.ok) {
-      setNewAccountLabel('');
-      setAccountsNotice(
-        `Added "${label}". Log in with: claude ${label} — then open a new shell (or source ~/.zshrc).`,
-      );
-      refreshAccounts();
-    } else {
-      setAccountsNotice('');
-      setAccountsError(r.error || 'Failed to add account');
-    }
+    runAccountOp(async () => {
+      const r = await window.electronAPI.addAccount(label);
+      if (r.ok) {
+        setNewAccountLabel('');
+        setAccountsNotice(
+          `Added "${label}". Log in with: claude ${label} — then open a new shell (or source ~/.zshrc).`,
+        );
+        await refreshAccounts();
+      } else {
+        setAccountsNotice('');
+        setAccountsError(r.error || 'Failed to add account');
+      }
+    });
   };
 
-  const handleRemoveAccount = async (label: string) => {
-    setAccountsError('');
-    const r = await window.electronAPI.removeAccount(label);
-    if (r.ok) {
-      setAccountsNotice(`Removed "${label}" (its folder stays on disk).`);
-      refreshAccounts();
-    } else {
-      setAccountsNotice('');
-      setAccountsError(r.error || 'Failed to remove account');
-    }
+  const handleRemoveAccount = (label: string) => {
+    runAccountOp(async () => {
+      const r = await window.electronAPI.removeAccount(label);
+      if (r.ok) {
+        setAccountsNotice(`Removed "${label}" (its folder stays on disk).`);
+        await refreshAccounts();
+      } else {
+        setAccountsNotice('');
+        setAccountsError(r.error || 'Failed to remove account');
+      }
+    });
   };
 
-  const handleSetDefaultAccount = async (label: string) => {
-    setAccountsError('');
-    const r = await window.electronAPI.setDefaultAccount(label);
-    if (r.ok) {
-      setAccountsNotice(
-        `Bare claude now resolves to "${label}" — open a new shell (or source ~/.zshrc).`,
-      );
-      refreshAccounts();
-    } else {
-      setAccountsNotice('');
-      setAccountsError(r.error || 'Failed to set default');
-    }
+  const handleSetDefaultAccount = (label: string) => {
+    runAccountOp(async () => {
+      const r = await window.electronAPI.setDefaultAccount(label);
+      if (r.ok) {
+        // Without the ~/.zshrc shell integration, the saved default isn't
+        // live in shells yet — say so instead of overpromising.
+        setAccountsNotice(
+          accountsShellInstalled
+            ? `Bare claude now resolves to "${label}" — open a new shell (or source ~/.zshrc).`
+            : `Default saved as "${label}" — install Shell integration below so bare claude uses it.`,
+        );
+        await refreshAccounts();
+      } else {
+        setAccountsNotice('');
+        setAccountsError(r.error || 'Failed to set default');
+      }
+    });
   };
 
-  const handleAccountsShellToggle = async () => {
-    setAccountsError('');
-    const r = await window.electronAPI.setAccountsShellHook(
-      accountsShellInstalled ? 'uninstall' : 'install',
-    );
-    if (r.ok) {
-      setAccountsNotice(
-        accountsShellInstalled
-          ? 'Removed the CodeV block from ~/.zshrc (registry and account folders kept).'
-          : 'Added the source block to ~/.zshrc — open a new shell to use claude <label>.',
+  const handleAccountsShellToggle = () => {
+    runAccountOp(async () => {
+      const r = await window.electronAPI.setAccountsShellHook(
+        accountsShellInstalled ? 'uninstall' : 'install',
       );
-      refreshAccounts();
-    } else {
-      setAccountsNotice('');
-      setAccountsError(r.error || 'Failed to update ~/.zshrc');
-    }
+      if (r.ok) {
+        setAccountsNotice(
+          accountsShellInstalled
+            ? 'Removed the CodeV block from ~/.zshrc (registry and account folders kept).'
+            : 'Added the source block to ~/.zshrc — open a new shell to use claude <label>.',
+        );
+        await refreshAccounts();
+      } else {
+        setAccountsNotice('');
+        setAccountsError(r.error || 'Failed to update ~/.zshrc');
+      }
+    });
   };
 
   useEffect(() => {
@@ -752,6 +785,7 @@ const PopupDefaultExample = ({
                     <button
                       style={smallButtonStyle}
                       onClick={() => handleSetDefaultAccount(a.label)}
+                      disabled={accountsBusy}
                       title="Make bare `claude` resolve to this account"
                     >
                       Set default
@@ -761,6 +795,7 @@ const PopupDefaultExample = ({
                     <button
                       style={{ ...smallButtonStyle, color: THEME.button.warning }}
                       onClick={() => handleRemoveAccount(a.label)}
+                      disabled={accountsBusy}
                       title="Unregister (keeps its folder on disk)"
                     >
                       Remove
@@ -780,14 +815,22 @@ const PopupDefaultExample = ({
                 placeholder="new account label (e.g. work)"
                 style={{ ...selectStyle, cursor: 'text', width: '170px' }}
               />
-              <button style={smallButtonStyle} onClick={handleAddAccount}>
+              <button
+                style={smallButtonStyle}
+                onClick={handleAddAccount}
+                disabled={accountsBusy}
+              >
                 Add account
               </button>
             </div>
 
             <div style={rowStyle}>
               <span style={labelStyle}>Shell integration (~/.zshrc)</span>
-              <button style={smallButtonStyle} onClick={handleAccountsShellToggle}>
+              <button
+                style={smallButtonStyle}
+                onClick={handleAccountsShellToggle}
+                disabled={accountsBusy}
+              >
                 {accountsShellInstalled ? 'Uninstall' : 'Install'}
               </button>
             </div>

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -776,8 +776,10 @@ const PopupDefaultExample = ({
                   </span>
                   <span style={{ fontSize: '11px', color: THEME.text.secondary }}>
                     {a.loggedIn
-                      ? a.email || 'logged in'
-                      : `not logged in — run: claude ${a.label}`}
+                      ? `${a.email || 'logged in'} — launch: ${
+                          a.isCurrentDefault ? 'claude' : `claude ${a.label}`
+                        }`
+                      : `not logged in — log in & launch: claude ${a.label}`}
                   </span>
                 </div>
                 <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
@@ -812,7 +814,7 @@ const PopupDefaultExample = ({
                 onKeyDown={(e) => {
                   if (e.key === 'Enter') handleAddAccount();
                 }}
-                placeholder="new account label (e.g. work)"
+                placeholder="account name (e.g. work)"
                 style={{ ...selectStyle, cursor: 'text', width: '170px' }}
               />
               <button
@@ -847,7 +849,8 @@ const PopupDefaultExample = ({
               </div>
             )}
             <div style={{ padding: '4px 16px', fontSize: '11px', color: THEME.text.secondary }}>
-              Registry: ~/.config/codev/accounts.json — launch with claude &lt;label&gt; or claude-&lt;label&gt;
+              Registry: ~/.config/codev/accounts.json — each account also has a
+              function form, e.g. claude-work
             </div>
           </div>
           )}

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -41,6 +41,17 @@ const labelStyle: React.CSSProperties = {
   color: THEME.text.primary,
 };
 
+const smallButtonStyle: React.CSSProperties = {
+  backgroundColor: '#333',
+  color: THEME.text.primary,
+  border: '1px solid #555',
+  borderRadius: '4px',
+  padding: '3px 10px',
+  fontSize: '12px',
+  cursor: 'pointer',
+  outline: 'none',
+};
+
 const PopupDefaultExample = ({
   workingFolderPath,
   saveCallback,
@@ -53,7 +64,7 @@ const PopupDefaultExample = ({
   saveCallback?: (key: string, value: string) => void;
   openCallback?: any;
   switcherMode?: string;
-  openToTab?: 'general' | 'sessions' | 'shortcuts' | null;
+  openToTab?: 'general' | 'sessions' | 'accounts' | 'shortcuts' | null;
   onOpenToTabConsumed?: () => void;
 }) => {
   const [isOpen, setIsOpen] = useState(false);
@@ -69,7 +80,7 @@ const PopupDefaultExample = ({
   const [isMASBuild, setIsMASBuild] = useState(false);
   const [sessionStatusHooks, setSessionStatusHooks] = useState(true);
   const [appModeState, setAppModeState] = useState('normal');
-  const [settingsTab, setSettingsTab] = useState<'general' | 'sessions' | 'shortcuts'>('general');
+  const [settingsTab, setSettingsTab] = useState<'general' | 'sessions' | 'accounts' | 'shortcuts'>('general');
   const [ideDataAccessGranted, setIdeDataAccessGranted] = useState(false);
   const [shortcuts, setShortcuts] = useState({
     quickSwitcher: 'Command+Control+R',
@@ -82,6 +93,100 @@ const PopupDefaultExample = ({
   const [updateStatus, setUpdateStatus] = useState<'idle' | 'checking' | 'downloading' | 'ready' | 'up-to-date' | 'error'>('idle');
   const [updateReleaseName, setUpdateReleaseName] = useState('');
   const [updateTimer, setUpdateTimer] = useState<ReturnType<typeof setTimeout> | null>(null);
+
+  // --- Accounts tab (codev multi-account, Batch 2b) ---
+  type AccountRow = {
+    label: string;
+    dir: string;
+    isDefault: boolean;
+    isCurrentDefault: boolean;
+    email?: string;
+    loggedIn?: boolean;
+  };
+  const [accounts, setAccounts] = useState<AccountRow[]>([]);
+  const [accountsShellInstalled, setAccountsShellInstalled] = useState(false);
+  const [accountsError, setAccountsError] = useState('');
+  const [accountsNotice, setAccountsNotice] = useState('');
+  const [newAccountLabel, setNewAccountLabel] = useState('');
+
+  const refreshAccounts = () => {
+    window.electronAPI.getAccounts().then((r) => {
+      if (r.ok) {
+        setAccounts((r.accounts as AccountRow[]) || []);
+        setAccountsShellInstalled(!!r.shellInstalled);
+      } else {
+        setAccountsError(r.error || 'Failed to load accounts');
+      }
+    });
+  };
+
+  useEffect(() => {
+    if (isOpen && settingsTab === 'accounts') {
+      refreshAccounts();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, settingsTab]);
+
+  const handleAddAccount = async () => {
+    const label = newAccountLabel.trim();
+    if (!label) return;
+    setAccountsError('');
+    const r = await window.electronAPI.addAccount(label);
+    if (r.ok) {
+      setNewAccountLabel('');
+      setAccountsNotice(
+        `Added "${label}". Log in with: claude ${label} — then open a new shell (or source ~/.zshrc).`,
+      );
+      refreshAccounts();
+    } else {
+      setAccountsNotice('');
+      setAccountsError(r.error || 'Failed to add account');
+    }
+  };
+
+  const handleRemoveAccount = async (label: string) => {
+    setAccountsError('');
+    const r = await window.electronAPI.removeAccount(label);
+    if (r.ok) {
+      setAccountsNotice(`Removed "${label}" (its folder stays on disk).`);
+      refreshAccounts();
+    } else {
+      setAccountsNotice('');
+      setAccountsError(r.error || 'Failed to remove account');
+    }
+  };
+
+  const handleSetDefaultAccount = async (label: string) => {
+    setAccountsError('');
+    const r = await window.electronAPI.setDefaultAccount(label);
+    if (r.ok) {
+      setAccountsNotice(
+        `Bare claude now resolves to "${label}" — open a new shell (or source ~/.zshrc).`,
+      );
+      refreshAccounts();
+    } else {
+      setAccountsNotice('');
+      setAccountsError(r.error || 'Failed to set default');
+    }
+  };
+
+  const handleAccountsShellToggle = async () => {
+    setAccountsError('');
+    const r = await window.electronAPI.setAccountsShellHook(
+      accountsShellInstalled ? 'uninstall' : 'install',
+    );
+    if (r.ok) {
+      setAccountsNotice(
+        accountsShellInstalled
+          ? 'Removed the CodeV block from ~/.zshrc (registry and account folders kept).'
+          : 'Added the source block to ~/.zshrc — open a new shell to use claude <label>.',
+      );
+      refreshAccounts();
+    } else {
+      setAccountsNotice('');
+      setAccountsError(r.error || 'Failed to update ~/.zshrc');
+    }
+  };
 
   useEffect(() => {
     window.electronAPI.getAppVersion().then((version: string) => {
@@ -337,7 +442,7 @@ const PopupDefaultExample = ({
 
           {/* Settings tabs */}
           <div style={{ display: 'flex', borderBottom: '1px solid #333', padding: '0 16px' }}>
-            {(['general', 'sessions', 'shortcuts'] as const).map((tab) => (
+            {(['general', 'sessions', 'accounts', 'shortcuts'] as const).map((tab) => (
               <button
                 key={tab}
                 onClick={() => {
@@ -618,6 +723,88 @@ const PopupDefaultExample = ({
                   }}
                 />
               </label>
+            </div>
+          </div>
+          )}
+
+          {/* Accounts tab */}
+          {settingsTab === 'accounts' && (
+          <div style={{ padding: '4px 0' }}>
+            {accounts.map((a) => (
+              <div key={a.label} style={rowStyle}>
+                <div style={{ display: 'flex', flexDirection: 'column' }}>
+                  <span style={labelStyle}>
+                    {a.label}
+                    {a.isCurrentDefault && (
+                      <span style={{ color: THEME.primary, fontSize: '11px', marginLeft: '6px' }}>
+                        default
+                      </span>
+                    )}
+                  </span>
+                  <span style={{ fontSize: '11px', color: THEME.text.secondary }}>
+                    {a.loggedIn
+                      ? a.email || 'logged in'
+                      : `not logged in — run: claude ${a.label}`}
+                  </span>
+                </div>
+                <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+                  {!a.isCurrentDefault && (
+                    <button
+                      style={smallButtonStyle}
+                      onClick={() => handleSetDefaultAccount(a.label)}
+                      title="Make bare `claude` resolve to this account"
+                    >
+                      Set default
+                    </button>
+                  )}
+                  {!a.isDefault && (
+                    <button
+                      style={{ ...smallButtonStyle, color: THEME.button.warning }}
+                      onClick={() => handleRemoveAccount(a.label)}
+                      title="Unregister (keeps its folder on disk)"
+                    >
+                      Remove
+                    </button>
+                  )}
+                </div>
+              </div>
+            ))}
+
+            <div style={rowStyle}>
+              <input
+                value={newAccountLabel}
+                onChange={(e) => setNewAccountLabel(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') handleAddAccount();
+                }}
+                placeholder="new account label (e.g. work)"
+                style={{ ...selectStyle, cursor: 'text', width: '170px' }}
+              />
+              <button style={smallButtonStyle} onClick={handleAddAccount}>
+                Add account
+              </button>
+            </div>
+
+            <div style={rowStyle}>
+              <span style={labelStyle}>Shell integration (~/.zshrc)</span>
+              <button style={smallButtonStyle} onClick={handleAccountsShellToggle}>
+                {accountsShellInstalled ? 'Uninstall' : 'Install'}
+              </button>
+            </div>
+
+            {(accountsError || accountsNotice) && (
+              <div
+                style={{
+                  padding: '4px 16px',
+                  fontSize: '11px',
+                  color: accountsError ? THEME.button.warning : THEME.text.folder,
+                }}
+              >
+                {accountsError || accountsNotice}
+              </div>
+            )}
+            <div style={{ padding: '4px 16px', fontSize: '11px', color: THEME.text.secondary }}>
+              Registry: ~/.config/codev/accounts.json — launch with claude &lt;label&gt; or claude-&lt;label&gt;
             </div>
           </div>
           )}

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -5,6 +5,14 @@ const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('electronAPI', {
   getHomeDir: () => ipcRenderer.invoke('get-home-dir'),
+  // codev multi-account (Settings → Accounts)
+  getAccounts: () => ipcRenderer.invoke('accounts-get'),
+  addAccount: (label: string) => ipcRenderer.invoke('accounts-add', label),
+  removeAccount: (label: string) => ipcRenderer.invoke('accounts-remove', label),
+  setDefaultAccount: (label: string) =>
+    ipcRenderer.invoke('accounts-set-default', label),
+  setAccountsShellHook: (action: 'install' | 'uninstall') =>
+    ipcRenderer.invoke('accounts-shell-hook', action),
   getBannerSeen: () => ipcRenderer.invoke('get-banner-seen'),
   setBannerSeen: () => ipcRenderer.send('set-banner-seen'),
   invokeVSCode: (path: string, option: string) =>


### PR DESCRIPTION
## Summary

Batch 2b (part 1) of multi-account support (follows #123): an **Accounts tab in Settings** — manage Claude Code accounts from the UI instead of the terminal.

- List configured accounts: label, identity (email / "not logged in" hint), `default` marker
- **Add** an account (creates the registry entry + regenerates `accounts.sh`; shows the `claude <label>` log-in hint)
- **Remove** an account (unregisters; keeps its folder on disk; anchor `~/.claude` account is protected)
- **Set default** — what bare `claude` resolves to (2e, now clickable)
- **Shell integration** install/uninstall (the marker-guarded `~/.zshrc` source block)

## Architecture

The tab is a set of thin IPC handlers (`accounts-get/add/remove/set-default/shell-hook` in `main.ts`) over **the same shared manager** (`src/cli/account-manager.ts`) that the `codev account` CLI uses — one generator for `accounts.json` + `accounts.sh`, no drift between CLI and UI. Mutations invalidate the accounts cache so the Sessions tab picks up changes.

- `src/popup.tsx` — new `accounts` tab (state + handlers + UI, matching the existing tab style)
- `src/preload.ts` / `src/electron-api.d.ts` — API wiring + `CodevAccountInfo` type
- `src/main.ts` — IPC handlers

## Scope notes

- **Rename** is deferred: labels name their dirs (`~/.claude-<label>`), so rename implies a dir migration; remove+add covers the rare need.
- **`codev` binary on PATH** is the remaining 2b item (next PR) — until then the CLI runs via `yarn account <cmd>`.

## Supported shells & terminals

- **Shell integration (Install button / `codev account install`)**: writes `~/.zshrc` — **zsh only** for now (the macOS default). The generated `accounts.sh` is bash-compatible (bash users can `source` it from `.bashrc` manually); **fish is unsupported** (different function syntax). Shell detection is future work (design doc §6.C).
- **Account-aware resume/launch**: every terminal CodeV supports — iTerm2, Terminal.app, Ghostty, cmux, and the embedded Term tab. VS Code sessions can't be account-switched (#121).

## Checking which account a session runs under (gotcha)

Inside any Claude Code session, `!claude auth status` reports the **global default**, not the session's account — Claude Code snapshots your interactive shell's functions, so in-session `claude` is the accounts.sh dispatcher. Valid probes:

- `!command claude auth status` ✅ — `command` bypasses shell functions, so the real binary inherits the session process's own `CLAUDE_CONFIG_DIR` → the session's actual account
- `!echo ${CLAUDE_CONFIG_DIR:-unset}` ✅ — the session's own config dir (`unset` = anchor account)

Full write-up: #123's "Gotcha" section + design doc §6.A.

## How to test

Needs `yarn make` (main-process + renderer changes):
1. Settings → **Accounts** tab: your accounts appear with email + `default` marker; shell integration shows Uninstall (already installed).
2. Add a `test` account → appears as "not logged in — run: claude test"; registry + `accounts.sh` regenerate.
3. `Set default` on `test` → notice appears; `yarn account list` shows `*` moved (restore after).
4. Remove `test` → gone from list; `~/.claude-test` folder stays.
5. Sessions tab still shows personal+work sessions with badges (cache invalidation works).

Automated: `yarn test` 13/13; `tsc --noEmit` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Accounts tab in Settings so you can manage Claude Code accounts from the UI instead of the terminal. This lets you add/remove accounts, set the default for bare `claude`, and toggle shell integration.

- **New Features**
  - List accounts with identity (email or “not logged in”), a “default” marker, and the exact launch command (`claude` or `claude <name>`).
  - Add an account (shows login hint: `claude <name>`), remove an account (keeps its folder), and set the global default.
  - Install/uninstall shell integration for `~/.zshrc`.
  - IPC handlers (`accounts-get/add/remove/set-default/shell-hook`) wrap the shared `account-manager` used by the `codev account` CLI; mutations invalidate the Sessions cache.
  - Notes: the anchor `~/.claude` account is protected; rename is deferred; remaining 2b item is a real `codev` binary on PATH.

- **Bug Fixes**
  - Seed the anchor `~/.claude` account on first extra add so the existing machine default stays registered and remains the global default.
  - `accounts-add` returns the enriched shape and derives `isCurrentDefault` in the fallback path to match `CodevAccountInfo`; shell-hook action is validated (malformed payloads fail).
  - UI hardening: async refresh with error handling, stale notices cleared on tab open, clear guidance when shell integration isn’t installed, and a busy guard to serialize account operations.

<sup>Written for commit b3e94f6f9f8c92a26818f6de2bfa3408de9ac6ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/grimmerk/codev/pull/124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **Accounts** tab in Settings for multi-account management.
  * Users can view accounts, add/remove accounts, and set the default (with current-default indicators).
  * Added UI to install/uninstall shell integration from the Accounts tab.
  * Settings can now open directly to the **Accounts** tab.
* **Chores**
  * Updated the app version to **v1.0.78** and refreshed the release entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
