### PR TITLE
feat(multi-account): account picker, claude tab completion, naming & rename (Batch 2c-lite)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   - Search-bar hint shows `⌥⌘+Enter: pick account` only for multi-account setups, and updates live after account changes (no app restart)
   - Tab completion for `claude <name>`: `claude <TAB>` completes account names (polite: skipped if another completion owns `claude`; other positions keep file completion)
   - Removed the stray `|` (react-select's default separator) before the search-bar hint
+  - Accounts UI: per-row **Rename**; the first-ever add asks what to name your existing `~/.claude` login (prefilled `main`) instead of assuming `personal`; `default` is now a reserved account name
+  - `codev account rename <old> <new>` (CLI) — labels are renameable; folders never move (credentials are keyed by the folder path)
   - README gains a Multi-Account section (shell commands, `codev account` CLI, UI map)
   - Roadmap: 2d (folder→account auto-switch) dropped — one folder legitimately hosts sessions from multiple accounts; cross-account *resume* stays deferred to Batch 3 (copy-fork design)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   - Search-bar hint shows `⌥⌘+Enter: pick account` only for multi-account setups, and updates live after account changes (no app restart)
   - Tab completion for `claude <name>`: `claude <TAB>` completes account names (polite: skipped if another completion owns `claude`; other positions keep file completion)
   - Removed the stray `|` (react-select's default separator) before the search-bar hint
-  - Accounts UI: per-row **Rename**; the first-ever add asks what to name your existing `~/.claude` login (prefilled `main`) instead of assuming `personal`; `default` is now a reserved account name
+  - Accounts UI: per-row **Rename**; the first-ever add asks what to name your existing `~/.claude` login (defaults to `main`) instead of assuming `personal`; `default` is now a reserved account name
   - `codev account rename <old> <new>` (CLI) — labels are renameable; folders never move (credentials are keyed by the folder path)
   - README gains a Multi-Account section (shell commands, `codev account` CLI, UI map)
   - Roadmap: 2d (folder→account auto-switch) dropped — one folder legitimately hosts sessions from multiple accounts; cross-account *resume* stays deferred to Batch 3 (copy-fork design)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,13 @@
 ## 1.0.80
 
 - Feat: multi-account Batch 2c-lite — pick the account when launching a new session
-  - `⌥⌘+Enter` on a project opens a small account picker (↑↓ / Enter / Esc, or click); the chosen account launches via explicit `CLAUDE_CONFIG_DIR` + `command claude`
+  - `⌥⌘+Enter` on a project opens a small account picker (↑↓ / Enter / Esc, or click); the chosen account launches via explicit `CLAUDE_CONFIG_DIR` + `command claude` (correct on iTerm2/Terminal.app/Ghostty/cmux)
   - Plain `⌘+Enter` unchanged: opens instantly under the global default; single-account (or registry-less) setups never see the picker
-  - Cross-account *resume* stays deferred to Batch 3 (copy-fork design; a session's transcript lives in its own account)
+  - Search-bar hint shows `⌥⌘+Enter: pick account` only for multi-account setups, and updates live after account changes (no app restart)
+  - Tab completion for `claude <name>`: `claude <TAB>` completes account names (polite: skipped if another completion owns `claude`; other positions keep file completion)
+  - Removed the stray `|` (react-select's default separator) before the search-bar hint
+  - README gains a Multi-Account section (shell commands, `codev account` CLI, UI map)
+  - Roadmap: 2d (folder→account auto-switch) dropped — one folder legitimately hosts sessions from multiple accounts; cross-account *resume* stays deferred to Batch 3 (copy-fork design)
 
 ## 1.0.79
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.0.80
 
 - Feat: multi-account Batch 2c-lite — pick the account when launching a new session
-  - `⌥⌘+Enter` on a project opens a small account picker (↑↓ / Enter / Esc, or click); the chosen account launches via explicit `CLAUDE_CONFIG_DIR` + `command claude` (correct on iTerm2/Terminal.app/Ghostty/cmux)
+  - `⌥⌘+Enter` on a project opens a small account picker (↑↓ / Enter / Esc, or click) — external terminals (iTerm2/Terminal.app/Ghostty/cmux); a non-default pick launches via explicit `CLAUDE_CONFIG_DIR` + `command claude`, a default-account pick via `env -u CLAUDE_CONFIG_DIR claude`
   - Plain `⌘+Enter` unchanged: opens instantly under the global default; single-account (or registry-less) setups never see the picker
   - Search-bar hint shows `⌥⌘+Enter: pick account` only for multi-account setups, and updates live after account changes (no app restart)
   - Tab completion for `claude <name>`: `claude <TAB>` completes account names (polite: skipped if another completion owns `claude`; other positions keep file completion)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.0.80
+
+- Feat: multi-account Batch 2c-lite — pick the account when launching a new session
+  - `⌥⌘+Enter` on a project opens a small account picker (↑↓ / Enter / Esc, or click); the chosen account launches via explicit `CLAUDE_CONFIG_DIR` + `command claude`
+  - Plain `⌘+Enter` unchanged: opens instantly under the global default; single-account (or registry-less) setups never see the picker
+  - Cross-account *resume* stays deferred to Batch 3 (copy-fork design; a session's transcript lives in its own account)
+
 ## 1.0.79
 
 - Feat: multi-account Batch 2b (part 2) — `codev` command in your shell

--- a/README.md
+++ b/README.md
@@ -88,13 +88,13 @@ The **default account** can be launched three equivalent ways: bare `claude`, `c
 
 | You are… | What happens / what to do |
 |----------|---------------------------|
-| An existing Claude Code user opening CodeV for the first time | Accounts tab is **empty** (zero footprint — no registry is created until you act); your `~/.claude` login keeps working as before. Add a second account and your existing login is auto-registered as `personal` alongside it. |
-| Unhappy with the auto-name `personal` | `codev account rename personal <name>` — or name it up front, before adding anything: `codev account add <name> --dir ~/.claude` registers your existing default itself (no extra account created). |
+| An existing Claude Code user opening CodeV for the first time | Accounts tab is **empty** (zero footprint — no registry is created until you act); your `~/.claude` login keeps working as before. When you add a second account, **you name your existing login at the same time** (a field appears, prefilled `main`) and both get registered together. |
+| Renaming any account later | The **Rename** button on each row, or `codev account rename <old> <new>`. To pre-name your existing default before adding anything: `codev account add <name> --dir ~/.claude` (registers the default itself; no extra account created). `default` is a reserved name. |
 | Starting fresh: add first, log in later | Add a name (UI or CLI) → it shows "not logged in" → in a new shell, `claude <name>` runs Claude Code's login and creates the folder. |
 | Already running a second account by hand (own shell function + custom folder) | Register it with `codev account add <name> --dir <your-folder>` — **any folder works**; `~/.claude-<name>` is only the default. Identity and sessions attach immediately, no re-login. If your hand-rolled wrapper was named `claude`, retire it (it would fight the generated dispatcher). |
-| Renaming any account (default or not) | `codev account rename <old> <new>` — changes only the name side of the *name → folder* mapping; folders never move, so name ≠ folder suffix is fine. |
+| Wondering why a name maps to a different folder | Renames change only the name side of the *name → folder* mapping; folders never move (credentials are keyed by the folder path) — the UI shows `· folder: …` on the row when they diverge. |
 
-> Not yet supported: auto-detecting existing config folders for one-click registration, a UI flow for naming/renaming accounts, and a warning when `accounts.sh` overrides a hand-rolled `claude()` shell function ([#127](https://github.com/grimmerk/codev/issues/127)); continuing an existing conversation under a *different* account — "copy-fork" — needs transcript-level workarounds first ([#128](https://github.com/grimmerk/codev/issues/128)).
+> Not yet supported: auto-detecting existing config folders for one-click registration, and a warning when `accounts.sh` overrides a hand-rolled `claude()` shell function ([#127](https://github.com/grimmerk/codev/issues/127)); continuing an existing conversation under a *different* account — "copy-fork" — needs transcript-level workarounds first ([#128](https://github.com/grimmerk/codev/issues/128)).
 
 The `codev` command runs the CLI **bundled inside CodeV.app** (`ELECTRON_RUN_AS_NODE`) — no system Node, no sudo, no PATH edits. CodeV refreshes `accounts.sh` on every launch, so moving or renaming the app self-heals. (Not available in MAS builds — sandboxed.)
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Tab completion included (zsh): `claude <TAB>` completes account names; `codev ac
 
 > **Add is just a mapping.** `add <name>` registers *name → config folder* (default `~/.claude-<name>` — that folder **is** the account's `CLAUDE_CONFIG_DIR`). Claude Code itself creates and fills the folder on first login (`claude <name>`).
 >
-> **Remove is non-destructive.** It only unregisters that mapping: the account's folder, login, and session history all stay on disk. `codev account add <name>` (or the UI) later reattaches everything — identity and sessions reappear immediately, no re-login needed.
+> **Remove is non-destructive.** It only unregisters that mapping: the account's folder, login, and session history all stay on disk. `codev account add <name>` (or the UI) later reattaches everything — identity and sessions reappear immediately, no re-login needed. **Caveat after a rename:** the folder keeps its *original* suffix (rename never moves folders), so re-attach with the folder-matching name — e.g. an account created as `work`, renamed to `ff`, then removed, re-attaches via `add work` (or any name with `--dir ~/.claude-work`), **not** `add ff`.
 
 **Common scenarios:**
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Run multiple Claude Code accounts (e.g. personal + work) on one machine. Each ac
 
 Tab completion included (zsh): `claude <TAB>` completes account names; `codev account <TAB>` completes subcommands and labels.
 
+The **default account** can be launched three equivalent ways: bare `claude`, `claude <its-name>`, or `claude-<its-name>` (the UI's row shows this).
+
 **`codev account` CLI** (the account manager — same generator the Settings UI uses):
 
 | Command | What it does |
@@ -76,7 +78,9 @@ Tab completion included (zsh): `claude <TAB>` completes account names; `codev ac
 | `codev account show` (`preview`) | Dry-run print of the generated `accounts.sh` |
 | `codev account install` / `uninstall` | Add / remove the `~/.zshrc` source block |
 
-> **Add is just a mapping.** `add <name>` registers *name → config folder* (default `~/.claude-<name>` — that folder **is** the account's `CLAUDE_CONFIG_DIR`). Claude Code itself creates and fills the folder on first login (`claude <name>`).
+> **Add is just a mapping.** `add <name>` registers *name → config folder* (default `~/.claude-<name>` — that folder **is** the account's `CLAUDE_CONFIG_DIR`). Claude Code itself creates and fills the folder on first login (`claude <name>`). One folder = one account: registering an already-registered folder under a second name is rejected.
+>
+> **Name vs folder.** The name is a mutable label; the folder is fixed at creation. They can diverge (after a rename) and the UI shows `· folder: …` on the row when they do. Folders deliberately never move on rename: Claude Code keys the account's credentials by the config-dir **path**, so moving the folder would orphan the login.
 >
 > **Remove is non-destructive.** It only unregisters that mapping: the account's folder, login, and session history all stay on disk. `codev account add <name>` (or the UI) later reattaches everything — identity and sessions reappear immediately, no re-login needed. **Caveat after a rename:** the folder keeps its *original* suffix (rename never moves folders), so re-attach with the folder-matching name — e.g. an account created as `work`, renamed to `ff`, then removed, re-attaches via `add work` (or any name with `--dir ~/.claude-work`), **not** `add ff`.
 
@@ -90,7 +94,7 @@ Tab completion included (zsh): `claude <TAB>` completes account names; `codev ac
 | Already running a second account by hand (own shell function + custom folder) | Register it with `codev account add <name> --dir <your-folder>` — **any folder works**; `~/.claude-<name>` is only the default. Identity and sessions attach immediately, no re-login. If your hand-rolled wrapper was named `claude`, retire it (it would fight the generated dispatcher). |
 | Renaming any account (default or not) | `codev account rename <old> <new>` — changes only the name side of the *name → folder* mapping; folders never move, so name ≠ folder suffix is fine. |
 
-> Not yet supported (tracked in [#127](https://github.com/grimmerk/codev/issues/127)): auto-detecting existing config folders for one-click registration, a UI flow for naming your existing default account, and a warning when `accounts.sh` overrides a hand-rolled `claude()` shell function.
+> Not yet supported: auto-detecting existing config folders for one-click registration, a UI flow for naming/renaming accounts, and a warning when `accounts.sh` overrides a hand-rolled `claude()` shell function ([#127](https://github.com/grimmerk/codev/issues/127)); continuing an existing conversation under a *different* account — "copy-fork" — needs transcript-level workarounds first ([#128](https://github.com/grimmerk/codev/issues/128)).
 
 The `codev` command runs the CLI **bundled inside CodeV.app** (`ELECTRON_RUN_AS_NODE`) — no system Node, no sudo, no PATH edits. CodeV refreshes `accounts.sh` on every launch, so moving or renaming the app self-heals. (Not available in MAS builds — sandboxed.)
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,52 @@ For the full same-cwd accuracy matrix (detection + switch by launch method and t
 | cmux | Title match → TTY fallback | CLI new-workspace | Same as iTerm2 (requires cmux v0.63+); requires socket access in cmux Settings (`automation` or `allowAll`) |
 | VS Code | URI handler (session-level) | `open -b` + URI handler | Requires Claude Code VS Code extension v2.1.72+; `[VSCODE]` badge on active sessions; adaptive resume via IDE lock file polling (~0.5s if project already open) |
 
+### Multi-Account Support (Claude Code)
+
+Run multiple Claude Code accounts (e.g. personal + work) on one machine. Each account gets its own config dir (via `CLAUDE_CONFIG_DIR`); the default account stays at `~/.claude` untouched. The Sessions tab aggregates sessions from every account (non-default ones get a purple account badge), and each session always resumes under the account it belongs to.
+
+**Setup** — Settings → Accounts:
+
+1. **Add** an account (e.g. `work`) — writes the registry (`~/.config/codev/accounts.json`) and generates `~/.config/codev/accounts.sh`
+2. **Install** Shell integration — appends one marker-guarded `source` line to `~/.zshrc` (zsh; the generated file is bash-sourceable manually, fish unsupported)
+3. Open a new shell and log in: `claude work`
+
+**Shell commands** (from the generated `accounts.sh`):
+
+| Command | What it does |
+|---------|--------------|
+| `claude` | Launches the **global default** account (configurable, see below) |
+| `claude <name> […]` | Launches that account, full passthrough (e.g. `claude work -r`) |
+| `claude-<name> […]` | Function form of the same (e.g. `claude-work mcp list`) |
+| `claude-whoami` | Which account bare `claude` resolves to here, plus its auth status |
+| `claude-accounts` | Quick list of configured accounts |
+
+Tab completion included (zsh): `claude <TAB>` completes account names; `codev account <TAB>` completes subcommands and labels.
+
+**`codev account` CLI** (the account manager — same generator the Settings UI uses):
+
+| Command | What it does |
+|---------|--------------|
+| `codev account list` (`ls`) | Accounts + identity; `*` marks the bare-`claude` default |
+| `codev account add <name> [--dir D]` | Register an account (default dir `~/.claude-<name>`) |
+| `codev account default <name>` | Point bare `claude` at an account |
+| `codev account remove <name>` (`rm`) | Unregister; keeps its folder on disk |
+| `codev account regenerate` (`regen`) | Rewrite `accounts.sh` from the registry |
+| `codev account show` (`preview`) | Dry-run print of the generated `accounts.sh` |
+| `codev account install` / `uninstall` | Add / remove the `~/.zshrc` source block |
+
+The `codev` command runs the CLI **bundled inside CodeV.app** (`ELECTRON_RUN_AS_NODE`) — no system Node, no sudo, no PATH edits. CodeV refreshes `accounts.sh` on every launch, so moving or renaming the app self-heals. (Not available in MAS builds — sandboxed.)
+
+**In the CodeV UI:**
+
+| Where | What |
+|-------|------|
+| Settings → Accounts | List/add/remove accounts, set the global default, install shell integration |
+| Sessions tab | Sessions from all accounts with account badges; resume uses each session's own account |
+| Projects tab: `⌥⌘+Enter` | Pick the account for a new session (`⌘+Enter` stays instant, under the global default) |
+
+**Gotcha:** inside a Claude Code session, `!claude auth status` reports the *global default* (the shell snapshot carries the dispatcher function), not the session's account — use `!command claude auth status` instead. Full design + details: [docs/multi-account-support-design.md](docs/multi-account-support-design.md).
+
 ### Embedded Terminal
 
 CodeV includes a built-in terminal tab (powered by xterm.js + node-pty, same technology as VS Code's integrated terminal). Press `⌃+⌘+T` from anywhere (global shortcut) or `⌘+3` when CodeV is in foreground to open it.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Run multiple Claude Code accounts (e.g. personal + work) on one machine. Each ac
 | `claude-whoami` | Which account bare `claude` resolves to here, plus its auth status |
 | `claude-accounts` | Quick list of configured accounts |
 
-Tab completion included (zsh): `claude <TAB>` completes account names; `codev account <TAB>` completes subcommands and labels.
+Tab completion included (zsh): `claude <TAB>` completes account names; `codev account <TAB>` completes subcommands and labels. (The `claude` completion is registered only when nothing else completes `claude` — if you already have one, account names won't be injected into it.)
 
 The **default account** can be launched three equivalent ways: bare `claude`, `claude <its-name>`, or `claude-<its-name>` (the UI's row shows this).
 
@@ -82,7 +82,7 @@ The **default account** can be launched three equivalent ways: bare `claude`, `c
 >
 > **Name vs folder.** The name is a mutable label; the folder is fixed at creation. They can diverge (after a rename) and the UI shows `· folder: …` on the row when they do. Folders deliberately never move on rename: Claude Code keys the account's credentials by the config-dir **path**, so moving the folder would orphan the login.
 >
-> **Remove is non-destructive.** It only unregisters that mapping: the account's folder, login, and session history all stay on disk. `codev account add <name>` (or the UI) later reattaches everything — identity and sessions reappear immediately, no re-login needed. **Caveat after a rename:** the folder keeps its *original* suffix (rename never moves folders), so re-attach with the folder-matching name — e.g. an account created as `work`, renamed to `ff`, then removed, re-attaches via `add work` (or any name with `--dir ~/.claude-work`), **not** `add ff`.
+> **Remove is non-destructive.** It only unregisters that mapping: the account's folder, login, and session history all stay on disk. `codev account add <name>` (or the UI) later reattaches everything — identity and sessions reappear immediately, no re-login needed. **Caveat after a rename:** the folder keeps its *original* suffix (rename never moves folders), so re-attach with the folder-matching name — e.g. an account created as `work`, renamed to `ff`, then removed, re-attaches via `add work` (or any name with `--dir ~/.claude-work`), **not** `add ff`. Likewise, an account originally registered with a custom `--dir` always needs `--dir <original-folder>` again on re-add.
 
 **Common scenarios:**
 
@@ -104,7 +104,7 @@ The `codev` command runs the CLI **bundled inside CodeV.app** (`ELECTRON_RUN_AS_
 |-------|------|
 | Settings → Accounts | List/add/remove accounts, set the global default, install shell integration |
 | Sessions tab | Sessions from all accounts with account badges; resume uses each session's own account |
-| Projects tab: `⌥⌘+Enter` | Pick the account for a new session (`⌘+Enter` stays instant, under the global default) |
+| Projects tab: `⌥⌘+Enter` | Pick the account for a new session (`⌘+Enter` stays instant, under the global default). Account override applies to external terminals (iTerm2, Terminal.app, Ghostty, cmux); VS Code ([#121](https://github.com/grimmerk/codev/issues/121)) and the embedded Term tab ignore it |
 
 **Gotcha:** inside a Claude Code session, `!claude auth status` reports the *global default* (the shell snapshot carries the dispatcher function), not the session's account — use `!command claude auth status` instead. Full design + details: [docs/multi-account-support-design.md](docs/multi-account-support-design.md).
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ Tab completion included (zsh): `claude <TAB>` completes account names; `codev ac
 >
 > **Remove is non-destructive.** It only unregisters that mapping: the account's folder, login, and session history all stay on disk. `codev account add <name>` (or the UI) later reattaches everything — identity and sessions reappear immediately, no re-login needed.
 
+**Common scenarios:**
+
+| You are… | What happens / what to do |
+|----------|---------------------------|
+| An existing Claude Code user opening CodeV for the first time | Accounts tab is **empty** (zero footprint — no registry is created until you act); your `~/.claude` login keeps working as before. Add a second account and your existing login is auto-registered as `personal` alongside it. |
+| Unhappy with the auto-name `personal` | `codev account rename personal <name>` — or name it up front, before adding anything: `codev account add <name> --dir ~/.claude` registers your existing default itself (no extra account created). |
+| Starting fresh: add first, log in later | Add a name (UI or CLI) → it shows "not logged in" → in a new shell, `claude <name>` runs Claude Code's login and creates the folder. |
+| Already running a second account by hand (own shell function + custom folder) | Register it with `codev account add <name> --dir <your-folder>` — **any folder works**; `~/.claude-<name>` is only the default. Identity and sessions attach immediately, no re-login. If your hand-rolled wrapper was named `claude`, retire it (it would fight the generated dispatcher). |
+| Renaming any account (default or not) | `codev account rename <old> <new>` — changes only the name side of the *name → folder* mapping; folders never move, so name ≠ folder suffix is fine. |
+
 The `codev` command runs the CLI **bundled inside CodeV.app** (`ELECTRON_RUN_AS_NODE`) — no system Node, no sudo, no PATH edits. CodeV refreshes `accounts.sh` on every launch, so moving or renaming the app self-heals. (Not available in MAS builds — sandboxed.)
 
 **In the CodeV UI:**

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The **default account** can be launched three equivalent ways: bare `claude`, `c
 
 | You are… | What happens / what to do |
 |----------|---------------------------|
-| An existing Claude Code user opening CodeV for the first time | Accounts tab is **empty** (zero footprint — no registry is created until you act); your `~/.claude` login keeps working as before. When you add a second account, **you name your existing login at the same time** (a field appears, prefilled `main`) and both get registered together. |
+| An existing Claude Code user opening CodeV for the first time | Accounts tab is **empty** (zero footprint — no registry is created until you act); your `~/.claude` login keeps working as before. When you add a second account, **you name your existing login at the same time** (a field appears; empty = `main`) and both get registered together. |
 | Renaming any account later | The **Rename** button on each row, or `codev account rename <old> <new>`. To pre-name your existing default before adding anything: `codev account add <name> --dir ~/.claude` (registers the default itself; no extra account created). `default` is a reserved name. |
 | Starting fresh: add first, log in later | Add a name (UI or CLI) → it shows "not logged in" → in a new shell, `claude <name>` runs Claude Code's login and creates the folder. |
 | Already running a second account by hand (own shell function + custom folder) | Register it with `codev account add <name> --dir <your-folder>` — **any folder works**; `~/.claude-<name>` is only the default. Identity and sessions attach immediately, no re-login. If your hand-rolled wrapper was named `claude`, retire it (it would fight the generated dispatcher). |

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Tab completion included (zsh): `claude <TAB>` completes account names; `codev ac
 | `codev account add <name> [--dir D]` | Register an account (default dir `~/.claude-<name>`) |
 | `codev account default <name>` | Point bare `claude` at an account |
 | `codev account remove <name>` (`rm`) | Unregister; keeps its folder on disk |
+| `codev account rename <old> <new>` | Rename a label — the folder is not moved; also the way to rename the auto-seeded default account (`personal`) |
 | `codev account regenerate` (`regen`) | Rewrite `accounts.sh` from the registry |
 | `codev account show` (`preview`) | Dry-run print of the generated `accounts.sh` |
 | `codev account install` / `uninstall` | Add / remove the `~/.zshrc` source block |

--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ Tab completion included (zsh): `claude <TAB>` completes account names; `codev ac
 | `codev account show` (`preview`) | Dry-run print of the generated `accounts.sh` |
 | `codev account install` / `uninstall` | Add / remove the `~/.zshrc` source block |
 
-> **Remove is non-destructive.** It only unregisters: the account's folder (`~/.claude-<name>`), login, and session history all stay on disk. `codev account add <name>` (or the UI) later reattaches everything — identity and sessions reappear immediately, no re-login needed.
+> **Add is just a mapping.** `add <name>` registers *name → config folder* (default `~/.claude-<name>` — that folder **is** the account's `CLAUDE_CONFIG_DIR`). Claude Code itself creates and fills the folder on first login (`claude <name>`).
+>
+> **Remove is non-destructive.** It only unregisters that mapping: the account's folder, login, and session history all stay on disk. `codev account add <name>` (or the UI) later reattaches everything — identity and sessions reappear immediately, no re-login needed.
 
 The `codev` command runs the CLI **bundled inside CodeV.app** (`ELECTRON_RUN_AS_NODE`) — no system Node, no sudo, no PATH edits. CodeV refreshes `accounts.sh` on every launch, so moving or renaming the app self-heals. (Not available in MAS builds — sandboxed.)
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Tab completion included (zsh): `claude <TAB>` completes account names; `codev ac
 | Already running a second account by hand (own shell function + custom folder) | Register it with `codev account add <name> --dir <your-folder>` — **any folder works**; `~/.claude-<name>` is only the default. Identity and sessions attach immediately, no re-login. If your hand-rolled wrapper was named `claude`, retire it (it would fight the generated dispatcher). |
 | Renaming any account (default or not) | `codev account rename <old> <new>` — changes only the name side of the *name → folder* mapping; folders never move, so name ≠ folder suffix is fine. |
 
+> Not yet supported (tracked in [#127](https://github.com/grimmerk/codev/issues/127)): auto-detecting existing config folders for one-click registration, a UI flow for naming your existing default account, and a warning when `accounts.sh` overrides a hand-rolled `claude()` shell function.
+
 The `codev` command runs the CLI **bundled inside CodeV.app** (`ELECTRON_RUN_AS_NODE`) — no system Node, no sudo, no PATH edits. CodeV refreshes `accounts.sh` on every launch, so moving or renaming the app self-heals. (Not available in MAS builds — sandboxed.)
 
 **In the CodeV UI:**

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Tab completion included (zsh): `claude <TAB>` completes account names; `codev ac
 | `codev account show` (`preview`) | Dry-run print of the generated `accounts.sh` |
 | `codev account install` / `uninstall` | Add / remove the `~/.zshrc` source block |
 
+> **Remove is non-destructive.** It only unregisters: the account's folder (`~/.claude-<name>`), login, and session history all stay on disk. `codev account add <name>` (or the UI) later reattaches everything — identity and sessions reappear immediately, no re-login needed.
+
 The `codev` command runs the CLI **bundled inside CodeV.app** (`ELECTRON_RUN_AS_NODE`) — no system Node, no sudo, no PATH edits. CodeV refreshes `accounts.sh` on every launch, so moving or renaming the app self-heals. (Not available in MAS builds — sandboxed.)
 
 **In the CodeV UI:**

--- a/docs/multi-account-support-design.md
+++ b/docs/multi-account-support-design.md
@@ -468,7 +468,8 @@ and **(d)** for CodeV, backed by the same `projectMap` in the registry so both a
     `env -u CLAUDE_CONFIG_DIR claude` instead — §3.4). Post-review naming UX: per-row UI Rename +
     `codev account rename` (label-only — folders never move; credentials are keyed by
     the config-dir path); the first-ever add asks what to name the existing ~/.claude
-    login (defaults to `main`, replacing the presumptuous auto-`personal`); `default` is
+    login (defaults to `main` — or `primary` when the new account itself is named
+    `main` — replacing the presumptuous auto-`personal`); `default` is
     a reserved label (it names the dispatcher-target concept). Cross-account *resume*
     (the other half of §6.G) stays deferred to Batch 3 as explicit copy-fork — a transcript lives in
     its own account's projects dir, so "resume under another account" must copy, never

--- a/docs/multi-account-support-design.md
+++ b/docs/multi-account-support-design.md
@@ -468,7 +468,14 @@ and **(d)** for CodeV, backed by the same `projectMap` in the registry so both a
     of §6.G) stays deferred to Batch 3 as explicit copy-fork — a transcript lives in
     its own account's projects dir, so "resume under another account" must copy, never
     link. "This repo always opens under X" belongs to 2d's projectMap.
-  - *2d:* pyenv-style folder auto-switch + terminal-side resume-to-right-account (§6.H).
+  - *2d — ❌ dropped (2026-07-10):* pyenv-style folder auto-switch (§6.H). Rationale:
+    in practice one folder hosts sessions from MULTIPLE accounts (we test exactly this
+    way), so a folder→account default would guess wrong precisely where the account
+    choice matters; stacking a third decision layer (global default → folder default →
+    picker) adds "why did bare claude open work here?" confusion for thin value. The
+    need is covered by 2e (global default) + 2c-lite (explicit per-launch picker).
+    Technically it was feasible (a default, not a constraint — resume always follows
+    the session's own account); dropped on value, not feasibility.
   - *2e:* configurable global-default (bare `claude` → chosen account) — last, since it
     also needs the CLI/UI to manage.
 - **Batch 3 — later:** cross-account symlink reuse of global files

--- a/docs/multi-account-support-design.md
+++ b/docs/multi-account-support-design.md
@@ -464,8 +464,12 @@ and **(d)** for CodeV, backed by the same `projectMap` in the registry so both a
   - *2c-lite (✅, branch `feat/new-session-account-picker`):* NEW-session account
     picker — ⌥⌘+Enter on a project opens a picker (⌘+Enter unchanged → global
     default; single-account setups never see it); launches with explicit
-    `CLAUDE_CONFIG_DIR` + `command claude`. Cross-account *resume* (the other half
-    of §6.G) stays deferred to Batch 3 as explicit copy-fork — a transcript lives in
+    `CLAUDE_CONFIG_DIR` + `command claude`. Post-review naming UX: per-row UI Rename +
+    `codev account rename` (label-only — folders never move; credentials are keyed by
+    the config-dir path); the first-ever add asks what to name the existing ~/.claude
+    login (prefilled `main`, replacing the presumptuous auto-`personal`); `default` is
+    a reserved label (it names the dispatcher-target concept). Cross-account *resume*
+    (the other half of §6.G) stays deferred to Batch 3 as explicit copy-fork — a transcript lives in
     its own account's projects dir, so "resume under another account" must copy, never
     link. "This repo always opens under X" belongs to 2d's projectMap.
   - *2d — ❌ dropped (2026-07-10):* pyenv-style folder auto-switch (§6.H). Rationale:

--- a/docs/multi-account-support-design.md
+++ b/docs/multi-account-support-design.md
@@ -453,8 +453,8 @@ and **(d)** for CodeV, backed by the same `projectMap` in the registry so both a
     registry + `accounts.sh` from one shared generator (§6.A/B); Vitest + CI added.
   - *2b (UI ✅, branch `feat/accounts-settings-ui`):* Accounts tab in Settings —
     list/add/remove + set-default + shell-integration toggle (§6.D), as IPC wrappers
-    over the shared manager (one generator with the CLI). Rename deferred (labels name
-    dirs; remove+add covers it).
+    over the shared manager (one generator with the CLI). (Rename was deferred here,
+    then shipped in 2c-lite below — CLI + per-row UI.)
   - *2b part 2 (✅, branch `feat/codev-path-binary`):* the `codev` command — a
     `codev()` function in accounts.sh runs the CLI bundled inside CodeV.app via
     `ELECTRON_RUN_AS_NODE` (no system Node; no sudo/PATH edits). The app records its
@@ -464,10 +464,11 @@ and **(d)** for CodeV, backed by the same `projectMap` in the registry so both a
   - *2c-lite (✅, branch `feat/new-session-account-picker`):* NEW-session account
     picker — ⌥⌘+Enter on a project opens a picker (⌘+Enter unchanged → global
     default; single-account setups never see it); launches with explicit
-    `CLAUDE_CONFIG_DIR` + `command claude`. Post-review naming UX: per-row UI Rename +
+    `CLAUDE_CONFIG_DIR` + `command claude` (an anchor-account pick uses
+    `env -u CLAUDE_CONFIG_DIR claude` instead — §3.4). Post-review naming UX: per-row UI Rename +
     `codev account rename` (label-only — folders never move; credentials are keyed by
     the config-dir path); the first-ever add asks what to name the existing ~/.claude
-    login (prefilled `main`, replacing the presumptuous auto-`personal`); `default` is
+    login (defaults to `main`, replacing the presumptuous auto-`personal`); `default` is
     a reserved label (it names the dispatcher-target concept). Cross-account *resume*
     (the other half of §6.G) stays deferred to Batch 3 as explicit copy-fork — a transcript lives in
     its own account's projects dir, so "resume under another account" must copy, never

--- a/docs/multi-account-support-design.md
+++ b/docs/multi-account-support-design.md
@@ -476,8 +476,10 @@ and **(d)** for CodeV, backed by the same `projectMap` in the registry so both a
     need is covered by 2e (global default) + 2c-lite (explicit per-launch picker).
     Technically it was feasible (a default, not a constraint — resume always follows
     the session's own account); dropped on value, not feasibility.
-  - *2e:* configurable global-default (bare `claude` → chosen account) — last, since it
-    also needs the CLI/UI to manage.
+  - *2e — ✅ shipped with 2a (PR #123, v1.0.77):* configurable global-default —
+    `codev account default <label>` / Settings → Set default routes bare `claude`
+    through the dispatcher `*)` to the chosen account; CodeV resume/launch bypass the
+    dispatcher with `command claude` so explicit account choices can't be re-routed.
 - **Batch 3 — later:** cross-account symlink reuse of global files
   (CLAUDE.md / skills / commands / plugins / settings, §5).
 

--- a/docs/multi-account-support-design.md
+++ b/docs/multi-account-support-design.md
@@ -461,7 +461,13 @@ and **(d)** for CodeV, backed by the same `projectMap` in the registry so both a
     real `.app` location in the registry (`appPath`) on every launch and refreshes
     accounts.sh, so app moves and generator updates self-heal. CLI is tsc-compiled
     into `resources/cli` (extraResource) at build time.
-  - *2c:* account picker / per-launch override (§6.G, 4.2).
+  - *2c-lite (✅, branch `feat/new-session-account-picker`):* NEW-session account
+    picker — ⌥⌘+Enter on a project opens a picker (⌘+Enter unchanged → global
+    default; single-account setups never see it); launches with explicit
+    `CLAUDE_CONFIG_DIR` + `command claude`. Cross-account *resume* (the other half
+    of §6.G) stays deferred to Batch 3 as explicit copy-fork — a transcript lives in
+    its own account's projects dir, so "resume under another account" must copy, never
+    link. "This repo always opens under X" belongs to 2d's projectMap.
   - *2d:* pyenv-style folder auto-switch + terminal-side resume-to-right-account (§6.H).
   - *2e:* configurable global-default (bare `claude` → chosen account) — last, since it
     also needs the CLI/UI to manage.

--- a/docs/multi-account-support-design.md
+++ b/docs/multi-account-support-design.md
@@ -478,8 +478,10 @@ and **(d)** for CodeV, backed by the same `projectMap` in the registry so both a
     the session's own account); dropped on value, not feasibility.
   - *2e — ✅ shipped with 2a (PR #123, v1.0.77):* configurable global-default —
     `codev account default <label>` / Settings → Set default routes bare `claude`
-    through the dispatcher `*)` to the chosen account; CodeV resume/launch bypass the
-    dispatcher with `command claude` so explicit account choices can't be re-routed.
+    through the dispatcher `*)` to the chosen account. CodeV bypasses the dispatcher
+    only for *account-explicit* operations (resuming a session under its own account,
+    picker launches) via `command claude` / explicit env; the plain ⌘+Enter new-session
+    path deliberately stays on bare `claude` so the dispatcher's global default applies.
 - **Batch 3 — later:** cross-account symlink reuse of global files
   (CLAUDE.md / skills / commands / plugins / settings, §5).
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "CodeV",
   "productName": "CodeV",
-  "version": "1.0.79",
+  "version": "1.0.80",
   "description": "Quick switcher for VS Code, Cursor, and Claude Code sessions",
   "repository": {
     "type": "git",

--- a/src/claude-session-utility.ts
+++ b/src/claude-session-utility.ts
@@ -1439,7 +1439,10 @@ export const launchNewClaudeSession = (
       ? `CLAUDE_CONFIG_DIR='${account.configDirEnv.replace(/'/g, "'\\''")}' command claude`
       : 'command claude';
   }
-  runCommandInTerminal(`cd "${projectPath}" && ${claudeCmd}`, 'claude', projectPath, terminalApp, terminalMode);
+  // Pass claudeCmd as the 2nd arg too — Ghostty/cmux build their launch
+  // scripts from it (iTerm2/Terminal.app use fullCommand), so the account
+  // env prefix must be present in both.
+  runCommandInTerminal(`cd "${projectPath}" && ${claudeCmd}`, claudeCmd, projectPath, terminalApp, terminalMode);
 };
 
 /**

--- a/src/claude-session-utility.ts
+++ b/src/claude-session-utility.ts
@@ -1435,9 +1435,21 @@ export const launchNewClaudeSession = (
   let claudeCmd = 'claude';
   if (accountLabel) {
     const account = getAccountByLabel(accountLabel);
-    claudeCmd = account?.configDirEnv
+    if (account?.label !== accountLabel) {
+      // Stale/unknown label (e.g. the account was removed after the picker
+      // loaded) — getAccountByLabel falls back to the default account, so
+      // abort instead of silently launching a different identity.
+      console.error(
+        '[launchNewClaudeSession] unknown account label, aborting:',
+        accountLabel,
+      );
+      return;
+    }
+    // Explicit pick of the default account: clear any inherited
+    // CLAUDE_CONFIG_DIR too (matches the generated accounts.sh launchers).
+    claudeCmd = account.configDirEnv
       ? `CLAUDE_CONFIG_DIR='${account.configDirEnv.replace(/'/g, "'\\''")}' command claude`
-      : 'command claude';
+      : 'env -u CLAUDE_CONFIG_DIR claude';
   }
   // Pass claudeCmd as the 2nd arg too — Ghostty/cmux build their launch
   // scripts from it (iTerm2/Terminal.app use fullCommand), so the account

--- a/src/claude-session-utility.ts
+++ b/src/claude-session-utility.ts
@@ -8,7 +8,11 @@ import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs';
 import { getCurrentIDEBundleId } from './vscode-based-ide-utility';
-import { getScannableAccounts, getProjectsDir } from './accounts';
+import {
+  getScannableAccounts,
+  getProjectsDir,
+  getAccountByLabel,
+} from './accounts';
 
 export interface ClaudeSession {
   sessionId: string;
@@ -1389,6 +1393,7 @@ export const launchNewClaudeSession = (
   projectPath: string,
   terminalApp: string = 'iterm2',
   terminalMode: string = 'tab',
+  accountLabel?: string,
 ): void => {
   if (terminalApp === 'vscode') {
     const { execFile } = require('child_process');
@@ -1411,12 +1416,30 @@ export const launchNewClaudeSession = (
     return;
   }
   if (terminalApp === 'codev') {
+    // Embedded terminal spawns the user's shell; the account override isn't
+    // threaded through it yet (the 2c-lite picker targets external terminals).
+    if (accountLabel) {
+      console.log(
+        '[launchNewClaudeSession] account override ignored for codev terminal:',
+        accountLabel,
+      );
+    }
     if (launchInCodevTerminalCallback) {
       launchInCodevTerminalCallback(projectPath);
     }
     return;
   }
-  runCommandInTerminal(`cd "${projectPath}" && claude`, 'claude', projectPath, terminalApp, terminalMode);
+  // No accountLabel: bare `claude` → the accounts.sh dispatcher → the user's
+  // global default (2e). With an explicit account (2c-lite picker): bypass the
+  // dispatcher via `command claude` + explicit env, like buildResumeCommand.
+  let claudeCmd = 'claude';
+  if (accountLabel) {
+    const account = getAccountByLabel(accountLabel);
+    claudeCmd = account?.configDirEnv
+      ? `CLAUDE_CONFIG_DIR='${account.configDirEnv.replace(/'/g, "'\\''")}' command claude`
+      : 'command claude';
+  }
+  runCommandInTerminal(`cd "${projectPath}" && ${claudeCmd}`, 'claude', projectPath, terminalApp, terminalMode);
 };
 
 /**

--- a/src/cli/account-manager.test.ts
+++ b/src/cli/account-manager.test.ts
@@ -156,6 +156,8 @@ describe('generateAccountsSh', () => {
     expect(sh).toContain('compadd personal work');
     // polite registration: only when nothing else completes `claude`
     expect(sh).toContain('[ -z "${_comps[claude]:-}" ]');
+    // non-label positions keep the default file completion
+    expect(sh).toContain('_files');
   });
 
   it('uses the recorded appExec so a renamed .app bundle still works', () => {

--- a/src/cli/account-manager.test.ts
+++ b/src/cli/account-manager.test.ts
@@ -142,9 +142,9 @@ describe('generateAccountsSh', () => {
     expect(sh).toContain('_codev() {');
     expect(sh).toContain('compdef _codev codev');
     expect(sh).toContain(
-      'compadd list add default remove rm regenerate show install uninstall help',
+      'compadd list add default remove rm rename regenerate show install uninstall help',
     );
-    expect(sh).toContain('default) compadd personal work ;;');
+    expect(sh).toContain('default|rename) compadd personal work ;;');
     // anchor (personal) is not removable
     expect(sh).toContain('remove|rm) compadd work ;;');
   });

--- a/src/cli/account-manager.test.ts
+++ b/src/cli/account-manager.test.ts
@@ -149,6 +149,15 @@ describe('generateAccountsSh', () => {
     expect(sh).toContain('remove|rm) compadd work ;;');
   });
 
+  it('completes account labels for `claude <TAB>` without clobbering', () => {
+    // Works even without appPath — the dispatcher exists whenever accounts do.
+    const sh = generateAccountsSh(reg());
+    expect(sh).toContain('_claude_codev_accounts() {');
+    expect(sh).toContain('compadd personal work');
+    // polite registration: only when nothing else completes `claude`
+    expect(sh).toContain('[ -z "${_comps[claude]:-}" ]');
+  });
+
   it('uses the recorded appExec so a renamed .app bundle still works', () => {
     const sh = generateAccountsSh(
       reg({

--- a/src/cli/account-manager.ts
+++ b/src/cli/account-manager.ts
@@ -331,11 +331,11 @@ export function generateAccountsSh(reg: Registry): string {
     L.push('    compadd account');
     L.push('  elif (( CURRENT == 3 )) && [ "${words[2]}" = "account" ]; then');
     L.push(
-      '    compadd list add default remove rm regenerate show install uninstall help',
+      '    compadd list add default remove rm rename regenerate show install uninstall help',
     );
     L.push('  elif (( CURRENT == 4 )) && [ "${words[2]}" = "account" ]; then');
     L.push('    case "${words[3]}" in');
-    if (allLabels) L.push(`      default) compadd ${allLabels} ;;`);
+    if (allLabels) L.push(`      default|rename) compadd ${allLabels} ;;`);
     if (removable) L.push(`      remove|rm) compadd ${removable} ;;`);
     L.push('    esac');
     L.push('  fi');
@@ -498,6 +498,31 @@ export function removeAccount(label: string): string | undefined {
   writeRegistry(reg);
   regenerate(reg);
   return reassignedDefault;
+}
+
+/**
+ * Rename an account's label (the folder is NOT moved — `dir` is stored in the
+ * registry, so extra accounts keep working even when label ≠ folder suffix).
+ * This is also the only way to rename the anchor (~/.claude) account, whose
+ * auto-seeded "personal" label can't be changed via remove+add (the anchor is
+ * protected from removal).
+ */
+export function renameAccount(oldLabel: string, newLabel: string): void {
+  if (!newLabel || !LABEL_RE.test(newLabel)) {
+    throw new Error(
+      `Invalid label "${newLabel}" — use a letter followed by letters/digits/-/_`,
+    );
+  }
+  const reg = readRegistry();
+  const acct = reg.accounts.find((a) => a.label === oldLabel);
+  if (!acct) throw new Error(`No account "${oldLabel}"`);
+  if (reg.accounts.some((a) => a.label === newLabel)) {
+    throw new Error(`Account "${newLabel}" already exists`);
+  }
+  acct.label = newLabel;
+  if (reg.defaultAccount === oldLabel) reg.defaultAccount = newLabel;
+  writeRegistry(reg);
+  regenerate(reg);
 }
 
 export function setDefault(label: string): void {

--- a/src/cli/account-manager.ts
+++ b/src/cli/account-manager.ts
@@ -357,7 +357,8 @@ export function generateAccountsSh(reg: Registry): string {
     L.push('# claude flags/subcommands still work — just not suggested).');
     L.push('_claude_codev_accounts() {');
     L.push('  if (( CURRENT == 2 )); then');
-    L.push(`    compadd ${allLabelsForClaude}`);
+    L.push('    # no label matches the typed prefix -> fall back to files');
+    L.push(`    compadd ${allLabelsForClaude} || _files`);
     L.push('  else');
     L.push('    # keep the default file completion for every other position');
     L.push('    _files');

--- a/src/cli/account-manager.ts
+++ b/src/cli/account-manager.ts
@@ -358,6 +358,9 @@ export function generateAccountsSh(reg: Registry): string {
     L.push('_claude_codev_accounts() {');
     L.push('  if (( CURRENT == 2 )); then');
     L.push(`    compadd ${allLabelsForClaude}`);
+    L.push('  else');
+    L.push('    # keep the default file completion for every other position');
+    L.push('    _files');
     L.push('  fi');
     L.push('}');
     L.push(

--- a/src/cli/account-manager.ts
+++ b/src/cli/account-manager.ts
@@ -346,6 +346,26 @@ export function generateAccountsSh(reg: Registry): string {
     L.push('  compdef _codev codev');
     L.push('fi');
   }
+  // Account-label completion for the `claude <label>` dispatcher. Registered
+  // only when nothing else completes `claude` (checked via _comps), so an
+  // official Claude Code completion — if one ever ships — wins automatically.
+  // Independent of appPath — the dispatcher exists whenever accounts do.
+  const allLabelsForClaude = accounts.map((a) => a.label).join(' ');
+  if (allLabelsForClaude) {
+    L.push('');
+    L.push('# Complete account names for `claude <TAB>` (labels only; native');
+    L.push('# claude flags/subcommands still work — just not suggested).');
+    L.push('_claude_codev_accounts() {');
+    L.push('  if (( CURRENT == 2 )); then');
+    L.push(`    compadd ${allLabelsForClaude}`);
+    L.push('  fi');
+    L.push('}');
+    L.push(
+      'if [ -n "${ZSH_VERSION:-}" ] && (( ${+functions[compdef]} )) && [ -z "${_comps[claude]:-}" ]; then',
+    );
+    L.push('  compdef _claude_codev_accounts claude');
+    L.push('fi');
+  }
   L.push('');
   return L.join('\n');
 }

--- a/src/cli/account-manager.ts
+++ b/src/cli/account-manager.ts
@@ -433,6 +433,16 @@ export function addAccount(
     opts.dir || path.join(os.homedir(), `.claude-${label}`),
   );
   assertSafeDir(dir);
+  // One folder = one account: a second mapping to the same dir would make
+  // CodeV double-scan its sessions and blur attribution.
+  const dupDir = reg.accounts.find(
+    (a) => path.resolve(expandHome(a.dir)) === path.resolve(dir),
+  );
+  if (dupDir) {
+    throw new Error(
+      `That folder is already registered as "${dupDir.label}" (${dir})`,
+    );
+  }
   const isDefault = isDefaultDir(dir);
   // Fresh registry + adding an EXTRA account: seed the anchor (~/.claude)
   // account first, so the machine's existing default install stays registered

--- a/src/cli/account-manager.ts
+++ b/src/cli/account-manager.ts
@@ -54,6 +54,11 @@ const ZSHRC_END = '# <<< codev accounts <<<';
 // Labels become shell function names + case branches, so keep them safe.
 const LABEL_RE = /^[a-zA-Z][a-zA-Z0-9_-]*$/;
 
+// 'default' is reserved: it already names the dispatcher's global-default
+// concept (the `default` badge, `codev account default`) — an account with
+// that name would be permanently confusing.
+const RESERVED_LABELS = new Set(['default']);
+
 export const expandHome = (p: string): string =>
   typeof p === 'string' && p.startsWith('~')
     ? path.join(os.homedir(), p.slice(1))
@@ -418,12 +423,17 @@ export function regenerate(reg?: Registry): string {
 
 export function addAccount(
   label: string,
-  opts: { dir?: string } = {},
+  opts: { dir?: string; anchorName?: string } = {},
 ): RegistryAccount {
   if (!label) throw new Error('add: <label> is required');
   if (!LABEL_RE.test(label)) {
     throw new Error(
       `Invalid label "${label}" — use a letter followed by letters/digits/-/_`,
+    );
+  }
+  if (RESERVED_LABELS.has(label)) {
+    throw new Error(
+      `"${label}" is reserved (it names the bare-claude target) — pick another name`,
     );
   }
   const reg = readRegistry();
@@ -450,7 +460,21 @@ export function addAccount(
   // and keeps the global default (instead of it silently moving to a
   // brand-new, not-yet-logged-in account).
   if (reg.accounts.length === 0 && !isDefault) {
-    const anchorLabel = label === 'personal' ? 'default' : 'personal';
+    // The anchor's name is the USER'S choice (UI first-add field / CLI
+    // --anchor-name); 'main' is only the neutral prefill — never assume
+    // 'personal' (the machine's first login may well be a company account).
+    const anchorLabel =
+      opts.anchorName || (label === 'main' ? 'primary' : 'main');
+    if (!LABEL_RE.test(anchorLabel) || RESERVED_LABELS.has(anchorLabel)) {
+      throw new Error(
+        `Invalid name "${anchorLabel}" for the existing ~/.claude account`,
+      );
+    }
+    if (anchorLabel === label) {
+      throw new Error(
+        'The new account and your existing (~/.claude) account need different names',
+      );
+    }
     const anchorIdentity = path.join(os.homedir(), '.claude.json');
     reg.accounts.push({
       label: anchorLabel,
@@ -522,6 +546,11 @@ export function renameAccount(oldLabel: string, newLabel: string): void {
   if (!newLabel || !LABEL_RE.test(newLabel)) {
     throw new Error(
       `Invalid label "${newLabel}" — use a letter followed by letters/digits/-/_`,
+    );
+  }
+  if (RESERVED_LABELS.has(newLabel)) {
+    throw new Error(
+      `"${newLabel}" is reserved (it names the bare-claude target) — pick another name`,
     );
   }
   const reg = readRegistry();

--- a/src/cli/codev-account.ts
+++ b/src/cli/codev-account.ts
@@ -23,6 +23,7 @@ Usage:
   codev account add <label> [--dir D] Register a new account (default dir ~/.claude-<label>)
   codev account default <label>      Set which account bare \`claude\` resolves to
   codev account remove <label>       Unregister an account (leaves its dir on disk)
+  codev account rename <old> <new>   Rename an account's label (folder is not moved)
   codev account regenerate           Rewrite ~/.config/codev/accounts.sh from the registry
   codev account show                 Print the generated accounts.sh (dry run, writes nothing)
   codev account install              Add the source line to ~/.zshrc (idempotent)
@@ -98,6 +99,14 @@ function main(): number {
       const label = rest[0];
       manager.setDefault(label);
       console.log(`✓ bare 'claude' now resolves to "${label}"`);
+      reloadHint();
+      return 0;
+    }
+
+    case 'rename': {
+      const [oldLabel, newLabel] = rest;
+      manager.renameAccount(oldLabel, newLabel);
+      console.log(`✓ Renamed "${oldLabel}" → "${newLabel}" (folder unchanged)`);
       reloadHint();
       return 0;
     }

--- a/src/cli/codev-account.ts
+++ b/src/cli/codev-account.ts
@@ -107,7 +107,11 @@ function main(): number {
       const [oldLabel, newLabel] = rest;
       manager.renameAccount(oldLabel, newLabel);
       console.log(`✓ Renamed "${oldLabel}" → "${newLabel}" (folder unchanged)`);
-      reloadHint();
+      // A plain `source ~/.zshrc` adds the new functions but does NOT unset
+      // the old claude-<oldLabel> in the current shell — recommend a new one.
+      console.log(
+        `  → open a NEW shell (sourcing would keep the old claude-${oldLabel} defined here)`,
+      );
       return 0;
     }
 

--- a/src/cli/codev-account.ts
+++ b/src/cli/codev-account.ts
@@ -23,7 +23,8 @@ Usage:
   codev account add <label> [--dir D] [--anchor-name N]
                                      Register a new account (default dir ~/.claude-<label>);
                                      on the first-ever add, N names your existing
-                                     ~/.claude account (default: main)
+                                     ~/.claude account (default: main — or primary
+                                     when the new account itself is named main)
   codev account default <label>      Set which account bare \`claude\` resolves to
   codev account remove <label>       Unregister an account (leaves its dir on disk)
   codev account rename <old> <new>   Rename an account's label (folder is not moved)

--- a/src/cli/codev-account.ts
+++ b/src/cli/codev-account.ts
@@ -20,7 +20,10 @@ const USAGE = `codev account — manage CodeV multi-account registry
 
 Usage:
   codev account list                 List configured accounts
-  codev account add <label> [--dir D] Register a new account (default dir ~/.claude-<label>)
+  codev account add <label> [--dir D] [--anchor-name N]
+                                     Register a new account (default dir ~/.claude-<label>);
+                                     on the first-ever add, N names your existing
+                                     ~/.claude account (default: main)
   codev account default <label>      Set which account bare \`claude\` resolves to
   codev account remove <label>       Unregister an account (leaves its dir on disk)
   codev account rename <old> <new>   Rename an account's label (folder is not moved)
@@ -79,13 +82,26 @@ function main(): number {
 
     case 'add': {
       const dir = getFlag(rest, '--dir');
-      // Skip the token consumed by `--dir` so `add --dir /foo work` still picks
+      const anchorName = getFlag(rest, '--anchor-name');
+      // Skip tokens consumed by flags so `add --dir /foo work` still picks
       // `work` as the label (not `/foo`).
-      const dirIdx = rest.indexOf('--dir');
-      const skipIdx = dirIdx >= 0 ? dirIdx + 1 : -1;
-      const label = rest.find((a, i) => !a.startsWith('-') && i !== skipIdx);
-      const acct = manager.addAccount(label as string, { dir });
+      const skip = new Set<number>();
+      for (const flag of ['--dir', '--anchor-name']) {
+        const i = rest.indexOf(flag);
+        if (i >= 0) skip.add(i + 1);
+      }
+      const label = rest.find((a, i) => !a.startsWith('-') && !skip.has(i));
+      const wasFresh = manager.readRegistry().accounts.length === 0;
+      const acct = manager.addAccount(label as string, { dir, anchorName });
       console.log(`✓ Added "${acct.label}"  (${acct.dir})`);
+      if (wasFresh && !acct.isDefault) {
+        const anchor = manager.listAccounts().find((x) => x.isDefault);
+        if (anchor) {
+          console.log(
+            `  Your existing ~/.claude login is registered as "${anchor.label}" (change: codev account rename ${anchor.label} <new>)`,
+          );
+        }
+      }
       if (!acct.loggedIn) {
         console.log(
           `  Log in with:  claude ${acct.label}   (or claude-${acct.label})`,

--- a/src/electron-api.d.ts
+++ b/src/electron-api.d.ts
@@ -23,12 +23,16 @@ interface IElectronAPI {
     accounts?: CodevAccountInfo[];
     shellInstalled?: boolean;
   }>;
-  addAccount: (label: string) => Promise<{
+  addAccount: (label: string, anchorName?: string) => Promise<{
     ok: boolean;
     error?: string;
     account?: CodevAccountInfo;
   }>;
   removeAccount: (label: string) => Promise<{ ok: boolean; error?: string }>;
+  renameAccount: (
+    oldLabel: string,
+    newLabel: string,
+  ) => Promise<{ ok: boolean; error?: string }>;
   setDefaultAccount: (label: string) => Promise<{ ok: boolean; error?: string }>;
   setAccountsShellHook: (action: 'install' | 'uninstall') => Promise<{
     ok: boolean;

--- a/src/electron-api.d.ts
+++ b/src/electron-api.d.ts
@@ -98,7 +98,7 @@ interface IElectronAPI {
   scanClosedVSCodeSessions: (activeSessionIds: string[]) => Promise<any[]>;
   refreshSessionPreview: (sessions: any[]) => Promise<Record<string, { lastUserMessage: string; lastAssistantMessage: string }>>;
   openClaudeSession: (sessionId: string, projectPath: string, isActive: boolean, activePid?: number, customTitle?: string) => void;
-  launchNewClaudeSession: (projectPath: string) => void;
+  launchNewClaudeSession: (projectPath: string, accountLabel?: string) => void;
   launchNewClaudeSessionInCodev: (projectPath: string) => void;
   copyClaudeSessionCommand: (sessionId: string, projectPath: string) => void;
   loadSessionEnrichment: (sessions: any[]) => Promise<{ titles: Record<string, string>; branches: Record<string, string>; prLinks: Record<string, { prNumber: number; prUrl: string }> }>;

--- a/src/main.ts
+++ b/src/main.ts
@@ -2276,14 +2276,14 @@ ipcMain.on('open-claude-session', async (_event, sessionId: string, projectPath:
   openSession(sessionId, projectPath, isActive, activePid, terminalApp, terminalMode, customTitle);
 });
 
-ipcMain.on('launch-new-claude-session', async (_event, projectPath: string) => {
+ipcMain.on('launch-new-claude-session', async (_event, projectPath: string, accountLabel?: string) => {
   if (!existsSync(projectPath)) {
     console.log('[launch-new-claude-session] path does not exist:', projectPath);
     return;
   }
   const terminalApp = ((await settings.get('session-terminal-app')) || 'iterm2') as string;
   const terminalMode = ((await settings.get('session-terminal-mode')) || 'tab') as string;
-  launchNewClaudeSession(projectPath, terminalApp, terminalMode);
+  launchNewClaudeSession(projectPath, terminalApp, terminalMode, accountLabel);
 });
 
 ipcMain.on('launch-new-claude-session-in-codev', (_event, projectPath: string) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -678,9 +678,9 @@ ipcMain.handle('accounts-get', () => {
   }
 });
 
-ipcMain.handle('accounts-add', (_event, label: string) => {
+ipcMain.handle('accounts-add', (_event, label: string, anchorName?: string) => {
   try {
-    const added = accountManager.addAccount(label);
+    const added = accountManager.addAccount(label, { anchorName });
     invalidateAccountsCache();
     // Return the enriched (listed) shape so it matches CodevAccountInfo
     // (isCurrentDefault etc.), not the raw registry entry. The fallback
@@ -712,6 +712,20 @@ ipcMain.handle('accounts-remove', (_event, label: string) => {
     return { ok: false, error: (error as Error).message };
   }
 });
+
+ipcMain.handle(
+  'accounts-rename',
+  (_event, oldLabel: string, newLabel: string) => {
+    try {
+      accountManager.renameAccount(oldLabel, newLabel);
+      invalidateAccountsCache();
+      syncAccountsAppPath();
+      return { ok: true };
+    } catch (error) {
+      return { ok: false, error: (error as Error).message };
+    }
+  },
+);
 
 ipcMain.handle('accounts-set-default', (_event, label: string) => {
   try {

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -825,6 +825,13 @@ const PopupDefaultExample = ({
                             : `claude ${a.label}`
                         }`
                       : `not logged in — log in & launch: claude ${a.label}`}
+                    {/* Name and folder can diverge (rename never moves
+                        folders) — surface the folder when they do. */}
+                    {!a.dir.endsWith(`/.claude-${a.label}`) && (
+                      <span style={{ color: '#777' }}>
+                        {` · folder: ${a.dir.replace(/^\/Users\/[^/]+/, '~')}`}
+                      </span>
+                    )}
                   </span>
                 </div>
                 <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
@@ -869,6 +876,11 @@ const PopupDefaultExample = ({
               >
                 Add account
               </button>
+            </div>
+            <div style={{ padding: '0 16px 4px', fontSize: '10px', color: '#777' }}>
+              Add creates or attaches the folder ~/.claude-&lt;name&gt; — to
+              attach an existing custom folder: codev account add &lt;name&gt;
+              --dir &lt;folder&gt;
             </div>
 
             <div style={rowStyle}>

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -110,6 +110,12 @@ const PopupDefaultExample = ({
   const [accountsNotice, setAccountsNotice] = useState('');
   const [newAccountLabel, setNewAccountLabel] = useState('');
   const [accountsBusy, setAccountsBusy] = useState(false);
+  // Footer example uses a REAL account name (prefer a non-default one) so
+  // nobody reads "work" as a fixed keyword.
+  const exampleAccountLabel =
+    accounts.find((a) => !a.isCurrentDefault)?.label ||
+    accounts[0]?.label ||
+    'work';
 
   const refreshAccounts = async () => {
     try {
@@ -883,8 +889,9 @@ const PopupDefaultExample = ({
               </div>
             )}
             <div style={{ padding: '4px 16px', fontSize: '11px', color: THEME.text.secondary }}>
-              Registry: ~/.config/codev/accounts.json — e.g. claude work or
-              claude-work (two equivalent forms, both launch that account)
+              Registry: ~/.config/codev/accounts.json — launch any account
+              above by its name: claude {exampleAccountLabel} and claude-
+              {exampleAccountLabel} are equivalent
             </div>
           </div>
           )}

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -883,8 +883,8 @@ const PopupDefaultExample = ({
               </div>
             )}
             <div style={{ padding: '4px 16px', fontSize: '11px', color: THEME.text.secondary }}>
-              Registry: ~/.config/codev/accounts.json — each account also has a
-              function form, e.g. claude-work
+              Registry: ~/.config/codev/accounts.json — e.g. claude work or
+              claude-work (two equivalent forms, both launch that account)
             </div>
           </div>
           )}

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -109,6 +109,12 @@ const PopupDefaultExample = ({
   const [accountsError, setAccountsError] = useState('');
   const [accountsNotice, setAccountsNotice] = useState('');
   const [newAccountLabel, setNewAccountLabel] = useState('');
+  // First-ever add also registers the existing ~/.claude login — the USER
+  // picks its name ('main' is only a neutral prefill; never assume
+  // 'personal': the machine's first login may be a company account).
+  const [anchorNameInput, setAnchorNameInput] = useState('main');
+  const [renamingLabel, setRenamingLabel] = useState<string | null>(null);
+  const [renameInput, setRenameInput] = useState('');
   const [accountsBusy, setAccountsBusy] = useState(false);
   // Footer example uses a REAL account name (prefer a non-default one) so
   // nobody reads it as a fixed keyword; the example clause is hidden entirely
@@ -165,15 +171,22 @@ const PopupDefaultExample = ({
   const handleAddAccount = () => {
     const label = newAccountLabel.trim();
     if (!label) return;
+    const isFirstAdd = accountsLoaded && accounts.length === 0;
+    const anchorName = isFirstAdd
+      ? anchorNameInput.trim() || 'main'
+      : undefined;
     runAccountOp(async () => {
-      const r = await window.electronAPI.addAccount(label);
+      const r = await window.electronAPI.addAccount(label, anchorName);
       if (r.ok) {
         setNewAccountLabel('');
         const dir = r.account?.dir || `~/.claude-${label}`;
+        const anchorNote = anchorName
+          ? ` Your existing login is registered as "${anchorName}".`
+          : '';
         setAccountsNotice(
           accountsShellInstalled
-            ? `Added "${label}" → ${dir}. Log in with: claude ${label} — then open a new shell (or source ~/.zshrc).`
-            : `Added "${label}" → ${dir}. Install Shell integration below, open a new shell, then log in with: claude ${label}.`,
+            ? `Added "${label}" → ${dir}.${anchorNote} Log in with: claude ${label} — then open a new shell (or source ~/.zshrc).`
+            : `Added "${label}" → ${dir}.${anchorNote} Install Shell integration below, open a new shell, then log in with: claude ${label}.`,
         );
         await refreshAccounts();
       } else {
@@ -198,6 +211,26 @@ const PopupDefaultExample = ({
       } else {
         setAccountsNotice('');
         setAccountsError(r.error || 'Failed to remove account');
+      }
+    });
+  };
+
+  const handleRenameAccount = (oldLabel: string, newLabel: string) => {
+    if (!newLabel || newLabel === oldLabel) {
+      setRenamingLabel(null);
+      return;
+    }
+    runAccountOp(async () => {
+      const r = await window.electronAPI.renameAccount(oldLabel, newLabel);
+      if (r.ok) {
+        setRenamingLabel(null);
+        setAccountsNotice(
+          `Renamed "${oldLabel}" → "${newLabel}" — folder unchanged; open a new shell for claude ${newLabel}.`,
+        );
+        await refreshAccounts();
+      } else {
+        setAccountsNotice('');
+        setAccountsError(r.error || 'Failed to rename');
       }
     });
   };
@@ -790,7 +823,7 @@ const PopupDefaultExample = ({
               }}
             >
               Claude Code (Anthropic) accounts — each launches claude with its
-              own config dir
+              own config dir. Names are renameable labels; folders never move.
             </div>
             {/* Only after a successful load — avoids flashing while the IPC
                 call is in flight and contradicting an error message. */}
@@ -803,22 +836,15 @@ const PopupDefaultExample = ({
                 }}
               >
                 No accounts registered yet — your existing ~/.claude login stays
-                the default. Add a second account below to go multi-account:
-                your existing login will show up here auto-named "personal"
-                (just a label — renameable via codev account rename).
+                the default. Add a second account below to go multi-account;
+                your existing login is registered at the same time, with the
+                name you set below.
               </div>
             )}
             {accounts.map((a) => (
               <div key={a.label} style={rowStyle}>
                 <div style={{ display: 'flex', flexDirection: 'column' }}>
-                  <span
-                    style={labelStyle}
-                    title={
-                      a.isDefault
-                        ? `Config dir: ${a.dir} — the name is just a label (auto-assigned at first add); change it: codev account rename <old> <new>`
-                        : `Config dir: ${a.dir}`
-                    }
-                  >
+                  <span style={labelStyle} title={`Config dir: ${a.dir}`}>
                     {a.label}
                     {a.isCurrentDefault && (
                       <span style={{ color: THEME.primary, fontSize: '11px', marginLeft: '6px' }}>
@@ -844,30 +870,88 @@ const PopupDefaultExample = ({
                   </span>
                 </div>
                 <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
-                  {!a.isCurrentDefault && (
-                    <button
-                      style={smallButtonStyle}
-                      onClick={() => handleSetDefaultAccount(a.label)}
-                      disabled={accountsBusy}
-                      title="Make bare `claude` resolve to this account"
-                    >
-                      Set default
-                    </button>
-                  )}
-                  {!a.isDefault && (
-                    <button
-                      style={{ ...smallButtonStyle, color: THEME.button.warning }}
-                      onClick={() => handleRemoveAccount(a.label)}
-                      disabled={accountsBusy}
-                      title="Unregister only — folder, login & sessions stay on disk; re-add the same name to reattach"
-                    >
-                      Remove
-                    </button>
+                  {renamingLabel === a.label ? (
+                    <>
+                      <input
+                        value={renameInput}
+                        onChange={(e) => setRenameInput(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') {
+                            handleRenameAccount(a.label, renameInput.trim());
+                          } else if (e.key === 'Escape') {
+                            setRenamingLabel(null);
+                          }
+                        }}
+                        autoFocus
+                        style={{ ...selectStyle, cursor: 'text', width: '110px' }}
+                      />
+                      <button
+                        style={smallButtonStyle}
+                        onClick={() => handleRenameAccount(a.label, renameInput.trim())}
+                        disabled={accountsBusy}
+                      >
+                        Save
+                      </button>
+                      <button
+                        style={smallButtonStyle}
+                        onClick={() => setRenamingLabel(null)}
+                        disabled={accountsBusy}
+                      >
+                        Cancel
+                      </button>
+                    </>
+                  ) : (
+                    <>
+                      <button
+                        style={smallButtonStyle}
+                        onClick={() => {
+                          setRenamingLabel(a.label);
+                          setRenameInput(a.label);
+                        }}
+                        disabled={accountsBusy}
+                        title="Rename the label — the folder never moves"
+                      >
+                        Rename
+                      </button>
+                      {!a.isCurrentDefault && (
+                        <button
+                          style={smallButtonStyle}
+                          onClick={() => handleSetDefaultAccount(a.label)}
+                          disabled={accountsBusy}
+                          title="Make bare `claude` resolve to this account"
+                        >
+                          Set default
+                        </button>
+                      )}
+                      {!a.isDefault && (
+                        <button
+                          style={{ ...smallButtonStyle, color: THEME.button.warning }}
+                          onClick={() => handleRemoveAccount(a.label)}
+                          disabled={accountsBusy}
+                          title="Unregister only — folder, login & sessions stay on disk; re-add the same name to reattach"
+                        >
+                          Remove
+                        </button>
+                      )}
+                    </>
                   )}
                 </div>
               </div>
             ))}
 
+            {accountsLoaded && accounts.length === 0 && (
+              <div style={rowStyle}>
+                <span style={{ fontSize: '12px', color: THEME.text.secondary }}>
+                  …and your existing ~/.claude login will be named
+                </span>
+                <input
+                  value={anchorNameInput}
+                  onChange={(e) => setAnchorNameInput(e.target.value)}
+                  disabled={accountsBusy}
+                  style={{ ...selectStyle, cursor: 'text', width: '110px' }}
+                />
+              </div>
+            )}
             <div style={rowStyle}>
               <input
                 value={newAccountLabel}

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -917,7 +917,9 @@ const PopupDefaultExample = ({
             <div style={{ padding: '4px 16px', fontSize: '11px', color: THEME.text.secondary }}>
               Registry: ~/.config/codev/accounts.json
               {accounts.length > 0 &&
-                ` — launch any account above by its name: claude ${exampleAccountLabel} and claude-${exampleAccountLabel} are equivalent`}
+                (accountsShellInstalled
+                  ? ` — launch any account above by its name: claude ${exampleAccountLabel} and claude-${exampleAccountLabel} are equivalent`
+                  : ' — install Shell integration above to launch accounts by name from the terminal')}
             </div>
           </div>
           )}

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -185,11 +185,15 @@ const PopupDefaultExample = ({
 
   const handleRemoveAccount = (label: string) => {
     runAccountOp(async () => {
+      // Capture the folder before it leaves the list — after a rename the
+      // label no longer matches the folder suffix, so "add the same name
+      // back" would point at the WRONG (empty) folder.
+      const removedDir = accounts.find((a) => a.label === label)?.dir;
       const r = await window.electronAPI.removeAccount(label);
       if (r.ok) {
         setAccountsNotice(
-        `Removed "${label}" — its folder, login and sessions stay on disk; add "${label}" back anytime to reattach them.`,
-      );
+          `Removed "${label}" — folder kept${removedDir ? ` (${removedDir})` : ''}, login and sessions intact. Re-attach later by adding a name that matches the folder suffix, or: codev account add <name> --dir <folder>.`,
+        );
         await refreshAccounts();
       } else {
         setAccountsNotice('');
@@ -816,7 +820,9 @@ const PopupDefaultExample = ({
                   <span style={{ fontSize: '11px', color: THEME.text.secondary }}>
                     {a.loggedIn
                       ? `${a.email || 'logged in'} — launch: ${
-                          a.isCurrentDefault ? 'claude' : `claude ${a.label}`
+                          a.isCurrentDefault
+                            ? `claude (or claude ${a.label})`
+                            : `claude ${a.label}`
                         }`
                       : `not logged in — log in & launch: claude ${a.label}`}
                   </span>

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -181,7 +181,9 @@ const PopupDefaultExample = ({
     runAccountOp(async () => {
       const r = await window.electronAPI.removeAccount(label);
       if (r.ok) {
-        setAccountsNotice(`Removed "${label}" (its folder stays on disk).`);
+        setAccountsNotice(
+        `Removed "${label}" — its folder, login and sessions stay on disk; add "${label}" back anytime to reattach them.`,
+      );
         await refreshAccounts();
       } else {
         setAccountsNotice('');
@@ -829,7 +831,7 @@ const PopupDefaultExample = ({
                       style={{ ...smallButtonStyle, color: THEME.button.warning }}
                       onClick={() => handleRemoveAccount(a.label)}
                       disabled={accountsBusy}
-                      title="Unregister (keeps its folder on disk)"
+                      title="Unregister only — folder, login & sessions stay on disk; re-add the same name to reattach"
                     >
                       Remove
                     </button>

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -119,6 +119,9 @@ const PopupDefaultExample = ({
         setAccountsLoaded(true);
         setAccountsShellInstalled(!!r.shellInstalled);
         setAccountsError('');
+        // Tell the surrounding switcher UI (same window) accounts changed,
+        // e.g. so the ⌥⌘+Enter hint updates without an app restart.
+        window.dispatchEvent(new CustomEvent('codev-accounts-changed'));
       } else {
         setAccountsNotice('');
         setAccountsError(r.error || 'Failed to load accounts');

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -110,9 +110,10 @@ const PopupDefaultExample = ({
   const [accountsNotice, setAccountsNotice] = useState('');
   const [newAccountLabel, setNewAccountLabel] = useState('');
   // First-ever add also registers the existing ~/.claude login — the USER
-  // picks its name ('main' is only a neutral prefill; never assume
-  // 'personal': the machine's first login may be a company account).
-  const [anchorNameInput, setAnchorNameInput] = useState('main');
+  // picks its name. Empty means "let the manager decide" ('main', or
+  // 'primary' when the new account itself is named main) so the backend
+  // fallback stays the single source of truth.
+  const [anchorNameInput, setAnchorNameInput] = useState('');
   const [renamingLabel, setRenamingLabel] = useState<string | null>(null);
   const [renameInput, setRenameInput] = useState('');
   const [accountsBusy, setAccountsBusy] = useState(false);
@@ -172,16 +173,21 @@ const PopupDefaultExample = ({
     const label = newAccountLabel.trim();
     if (!label) return;
     const isFirstAdd = accountsLoaded && accounts.length === 0;
+    // Pass undefined when untouched so the manager's fallback applies
+    // ('main', or 'primary' when the new account itself is named main).
     const anchorName = isFirstAdd
-      ? anchorNameInput.trim() || 'main'
+      ? anchorNameInput.trim() || undefined
+      : undefined;
+    const effectiveAnchor = isFirstAdd
+      ? anchorName || (label === 'main' ? 'primary' : 'main')
       : undefined;
     runAccountOp(async () => {
       const r = await window.electronAPI.addAccount(label, anchorName);
       if (r.ok) {
         setNewAccountLabel('');
         const dir = r.account?.dir || `~/.claude-${label}`;
-        const anchorNote = anchorName
-          ? ` Your existing login is registered as "${anchorName}".`
+        const anchorNote = effectiveAnchor
+          ? ` Your existing login is registered as "${effectiveAnchor}".`
           : '';
         setAccountsNotice(
           accountsShellInstalled
@@ -947,6 +953,7 @@ const PopupDefaultExample = ({
                 <input
                   value={anchorNameInput}
                   onChange={(e) => setAnchorNameInput(e.target.value)}
+                  placeholder="main"
                   disabled={accountsBusy}
                   style={{ ...selectStyle, cursor: 'text', width: '110px' }}
                 />

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -803,13 +803,22 @@ const PopupDefaultExample = ({
                 }}
               >
                 No accounts registered yet — your existing ~/.claude login stays
-                the default. Add a second account below to go multi-account.
+                the default. Add a second account below to go multi-account:
+                your existing login will show up here auto-named "personal"
+                (just a label — renameable via codev account rename).
               </div>
             )}
             {accounts.map((a) => (
               <div key={a.label} style={rowStyle}>
                 <div style={{ display: 'flex', flexDirection: 'column' }}>
-                  <span style={labelStyle} title={`Config dir: ${a.dir}`}>
+                  <span
+                    style={labelStyle}
+                    title={
+                      a.isDefault
+                        ? `Config dir: ${a.dir} — the name is just a label (auto-assigned at first add); change it: codev account rename <old> <new>`
+                        : `Config dir: ${a.dir}`
+                    }
+                  >
                     {a.label}
                     {a.isCurrentDefault && (
                       <span style={{ color: THEME.primary, fontSize: '11px', marginLeft: '6px' }}>

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -164,10 +164,11 @@ const PopupDefaultExample = ({
       const r = await window.electronAPI.addAccount(label);
       if (r.ok) {
         setNewAccountLabel('');
+        const dir = r.account?.dir || `~/.claude-${label}`;
         setAccountsNotice(
           accountsShellInstalled
-            ? `Added "${label}". Log in with: claude ${label} — then open a new shell (or source ~/.zshrc).`
-            : `Added "${label}". Install Shell integration below, open a new shell, then log in with: claude ${label}.`,
+            ? `Added "${label}" → ${dir}. Log in with: claude ${label} — then open a new shell (or source ~/.zshrc).`
+            : `Added "${label}" → ${dir}. Install Shell integration below, open a new shell, then log in with: claude ${label}.`,
         );
         await refreshAccounts();
       } else {
@@ -799,7 +800,7 @@ const PopupDefaultExample = ({
             {accounts.map((a) => (
               <div key={a.label} style={rowStyle}>
                 <div style={{ display: 'flex', flexDirection: 'column' }}>
-                  <span style={labelStyle}>
+                  <span style={labelStyle} title={`Config dir: ${a.dir}`}>
                     {a.label}
                     {a.isCurrentDefault && (
                       <span style={{ color: THEME.primary, fontSize: '11px', marginLeft: '6px' }}>

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -111,11 +111,10 @@ const PopupDefaultExample = ({
   const [newAccountLabel, setNewAccountLabel] = useState('');
   const [accountsBusy, setAccountsBusy] = useState(false);
   // Footer example uses a REAL account name (prefer a non-default one) so
-  // nobody reads "work" as a fixed keyword.
+  // nobody reads it as a fixed keyword; the example clause is hidden entirely
+  // when no account is registered (the commands wouldn't exist yet).
   const exampleAccountLabel =
-    accounts.find((a) => !a.isCurrentDefault)?.label ||
-    accounts[0]?.label ||
-    'work';
+    accounts.find((a) => !a.isCurrentDefault)?.label || accounts[0]?.label;
 
   const refreshAccounts = async () => {
     try {
@@ -889,9 +888,9 @@ const PopupDefaultExample = ({
               </div>
             )}
             <div style={{ padding: '4px 16px', fontSize: '11px', color: THEME.text.secondary }}>
-              Registry: ~/.config/codev/accounts.json — launch any account
-              above by its name: claude {exampleAccountLabel} and claude-
-              {exampleAccountLabel} are equivalent
+              Registry: ~/.config/codev/accounts.json
+              {accounts.length > 0 &&
+                ` — launch any account above by its name: claude ${exampleAccountLabel} and claude-${exampleAccountLabel} are equivalent`}
             </div>
           </div>
           )}

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -71,8 +71,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   refreshSessionPreview: (sessions: any[]) => ipcRenderer.invoke('refresh-session-preview', sessions),
   openClaudeSession: (sessionId: string, projectPath: string, isActive: boolean, activePid?: number, customTitle?: string) =>
     ipcRenderer.send('open-claude-session', sessionId, projectPath, isActive, activePid, customTitle),
-  launchNewClaudeSession: (projectPath: string) =>
-    ipcRenderer.send('launch-new-claude-session', projectPath),
+  launchNewClaudeSession: (projectPath: string, accountLabel?: string) =>
+    ipcRenderer.send('launch-new-claude-session', projectPath, accountLabel),
   launchNewClaudeSessionInCodev: (projectPath: string) =>
     ipcRenderer.send('launch-new-claude-session-in-codev', projectPath),
   copyClaudeSessionCommand: (sessionId: string, projectPath: string) =>

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -7,8 +7,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getHomeDir: () => ipcRenderer.invoke('get-home-dir'),
   // codev multi-account (Settings → Accounts)
   getAccounts: () => ipcRenderer.invoke('accounts-get'),
-  addAccount: (label: string) => ipcRenderer.invoke('accounts-add', label),
+  addAccount: (label: string, anchorName?: string) =>
+    ipcRenderer.invoke('accounts-add', label, anchorName),
   removeAccount: (label: string) => ipcRenderer.invoke('accounts-remove', label),
+  renameAccount: (oldLabel: string, newLabel: string) =>
+    ipcRenderer.invoke('accounts-rename', oldLabel, newLabel),
   setDefaultAccount: (label: string) =>
     ipcRenderer.invoke('accounts-set-default', label),
   setAccountsShellHook: (action: 'install' | 'uninstall') =>

--- a/src/switcher-ui.tsx
+++ b/src/switcher-ui.tsx
@@ -290,7 +290,13 @@ function SwitcherApp() {
   const openAccountPickerForLaunch = async (projectPath: string) => {
     try {
       const r = await window.electronAPI.getAccounts();
-      const accounts = ((r.ok && r.accounts) || []) as LaunchAccount[];
+      if (!r.ok) {
+        // The user explicitly asked to pick — don't guess an identity when
+        // the account list can't be loaded.
+        console.error('[account-picker] failed to load accounts:', r.error);
+        return;
+      }
+      const accounts = (r.accounts || []) as LaunchAccount[];
       if (accounts.length <= 1) {
         // Single account (or no registry): nothing to pick — launch as usual.
         window.electronAPI.launchNewClaudeSession(projectPath);
@@ -298,8 +304,8 @@ function SwitcherApp() {
       }
       setLaunchPickerIndex(0);
       setLaunchPicker({ path: projectPath, accounts });
-    } catch {
-      window.electronAPI.launchNewClaudeSession(projectPath);
+    } catch (e) {
+      console.error('[account-picker] failed to load accounts:', e);
     }
   };
 
@@ -598,12 +604,20 @@ function SwitcherApp() {
     });
 
     // Account count decides whether the ⌥⌘+Enter picker hint is shown.
-    window.electronAPI
-      .getAccounts()
-      .then((r) => {
-        if (r.ok) setIsMultiAccountUI(((r.accounts || []) as unknown[]).length > 1);
-      })
-      .catch(() => {});
+    // Re-checked when the embedded Settings popup mutates accounts (same-window
+    // CustomEvent) and on window focus (covers CLI-side changes) — no restart
+    // needed for the hint to switch.
+    const refreshMultiAccountHint = () => {
+      window.electronAPI
+        .getAccounts()
+        .then((r) => {
+          if (r.ok) setIsMultiAccountUI(((r.accounts || []) as unknown[]).length > 1);
+        })
+        .catch(() => {});
+    };
+    refreshMultiAccountHint();
+    window.addEventListener('codev-accounts-changed', refreshMultiAccountHint);
+    window.addEventListener('focus', refreshMultiAccountHint);
 
     // If initial mode is sessions (from URL hash), fetch sessions immediately
     if (initialMode === 'sessions') {
@@ -1573,6 +1587,9 @@ function SwitcherApp() {
         }}
         // Custom components
         components={{
+          // Hide react-select's default vertical separator ("|" that looks
+          // like a stray cursor before the hint text).
+          IndicatorSeparator: () => null,
           DropdownIndicator: () => (
             <div
               title="\u2325\u2318+Enter: choose the account first"

--- a/src/switcher-ui.tsx
+++ b/src/switcher-ui.tsx
@@ -269,7 +269,42 @@ const formatRelativeTime = (timestamp: string): string => {
 let loadTimes = 0;
 function SwitcherApp() {
   const optionPress = useRef(false);
-  const launchClaudeRef = useRef<'external' | 'codev' | null>(null);
+  const launchClaudeRef = useRef<'external' | 'codev' | 'external-pick' | null>(null);
+
+  // 2c-lite: ⌥⌘+Enter — pick the account for a new-session launch.
+  type LaunchAccount = {
+    label: string;
+    email?: string;
+    loggedIn?: boolean;
+    isCurrentDefault: boolean;
+  };
+  const [launchPicker, setLaunchPicker] = useState<{
+    path: string;
+    accounts: LaunchAccount[];
+  } | null>(null);
+  const [launchPickerIndex, setLaunchPickerIndex] = useState(0);
+
+  const openAccountPickerForLaunch = async (projectPath: string) => {
+    try {
+      const r = await window.electronAPI.getAccounts();
+      const accounts = ((r.ok && r.accounts) || []) as LaunchAccount[];
+      if (accounts.length <= 1) {
+        // Single account (or no registry): nothing to pick — launch as usual.
+        window.electronAPI.launchNewClaudeSession(projectPath);
+        return;
+      }
+      setLaunchPickerIndex(0);
+      setLaunchPicker({ path: projectPath, accounts });
+    } catch {
+      window.electronAPI.launchNewClaudeSession(projectPath);
+    }
+  };
+
+  const pickLaunchAccount = (account: LaunchAccount) => {
+    if (!launchPicker) return;
+    window.electronAPI.launchNewClaudeSession(launchPicker.path, account.label);
+    setLaunchPicker(null);
+  };
 
   const ref = useRef(null);
   const sessionSearchRef = useRef<HTMLInputElement>(null);
@@ -1496,7 +1531,13 @@ function SwitcherApp() {
           // Clear on every keypress to prevent stale ref if onChange didn't fire
           launchClaudeRef.current = null;
           if (evt.key === 'Enter' && (evt.metaKey || evt.shiftKey)) {
-            launchClaudeRef.current = evt.shiftKey ? 'codev' : 'external';
+            // ⌥⌘+Enter: choose the account first (multi-account, 2c-lite)
+            launchClaudeRef.current =
+              evt.metaKey && evt.altKey
+                ? 'external-pick'
+                : evt.shiftKey
+                  ? 'codev'
+                  : 'external';
           }
         }}
         onInputChange={(evt) => {
@@ -1507,6 +1548,8 @@ function SwitcherApp() {
           launchClaudeRef.current = null;
           if (launchMode === 'codev') {
             window.electronAPI.launchNewClaudeSessionInCodev(evt.value);
+          } else if (launchMode === 'external-pick') {
+            openAccountPickerForLaunch(evt.value);
           } else if (launchMode === 'external') {
             window.electronAPI.launchNewClaudeSession(evt.value);
           } else {
@@ -1520,7 +1563,10 @@ function SwitcherApp() {
         // Custom components
         components={{
           DropdownIndicator: () => (
-            <div style={{ fontSize: '11px', color: '#666', paddingRight: '8px', whiteSpace: 'nowrap' }}>
+            <div
+              title="\u2325\u2318+Enter: choose the account first"
+              style={{ fontSize: '11px', color: '#666', paddingRight: '8px', whiteSpace: 'nowrap' }}
+            >
               {'\u2318+Enter: New Claude'}
             </div>
           ),
@@ -1679,6 +1725,86 @@ function SwitcherApp() {
           }),
         }}
       />
+      {launchPicker && (
+        <div
+          data-settings-panel
+          onClick={() => setLaunchPicker(null)}
+          style={{
+            position: 'fixed',
+            inset: 0,
+            background: 'rgba(0, 0, 0, 0.45)',
+            zIndex: 1000,
+            display: 'flex',
+            alignItems: 'flex-start',
+            justifyContent: 'center',
+          }}
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => {
+              e.stopPropagation();
+              if (e.key === 'Escape') {
+                setLaunchPicker(null);
+              } else if (e.key === 'ArrowDown') {
+                e.preventDefault();
+                setLaunchPickerIndex((i) => (i + 1) % launchPicker.accounts.length);
+              } else if (e.key === 'ArrowUp') {
+                e.preventDefault();
+                setLaunchPickerIndex(
+                  (i) => (i - 1 + launchPicker.accounts.length) % launchPicker.accounts.length,
+                );
+              } else if (e.key === 'Enter') {
+                e.preventDefault();
+                pickLaunchAccount(launchPicker.accounts[launchPickerIndex]);
+              }
+            }}
+            tabIndex={0}
+            ref={(el) => el?.focus()}
+            style={{
+              marginTop: '120px',
+              minWidth: '320px',
+              background: '#252526',
+              border: '1px solid #454545',
+              borderRadius: '8px',
+              padding: '8px',
+              boxShadow: '0 8px 24px rgba(0, 0, 0, 0.5)',
+              outline: 'none',
+            }}
+          >
+            <div style={{ fontSize: '11px', color: '#888', padding: '2px 8px 6px' }}>
+              New Claude in {launchPicker.path.split('/').pop()} as… (↑↓ · Enter · Esc)
+            </div>
+            {launchPicker.accounts.map((a, i) => (
+              <div
+                key={a.label}
+                onClick={() => pickLaunchAccount(a)}
+                onMouseEnter={() => setLaunchPickerIndex(i)}
+                style={{
+                  padding: '6px 8px',
+                  borderRadius: '4px',
+                  cursor: 'pointer',
+                  backgroundColor: i === launchPickerIndex ? '#094771' : 'transparent',
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  gap: '12px',
+                }}
+              >
+                <span style={{ color: '#e9e9e9', fontSize: '13px' }}>
+                  {a.label}
+                  {a.isCurrentDefault && (
+                    <span style={{ color: '#00BCD4', fontSize: '10px', marginLeft: '6px' }}>
+                      default
+                    </span>
+                  )}
+                </span>
+                <span style={{ color: '#888', fontSize: '11px' }}>
+                  {a.loggedIn ? a.email || '' : 'not logged in'}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
       </div>
       ))}
     </div>

--- a/src/switcher-ui.tsx
+++ b/src/switcher-ui.tsx
@@ -283,6 +283,9 @@ function SwitcherApp() {
     accounts: LaunchAccount[];
   } | null>(null);
   const [launchPickerIndex, setLaunchPickerIndex] = useState(0);
+  // Multi-account? → advertise ⌥⌘+Enter in the search-bar hint (single-account
+  // users see the unchanged short hint — no extra clutter).
+  const [isMultiAccountUI, setIsMultiAccountUI] = useState(false);
 
   const openAccountPickerForLaunch = async (projectPath: string) => {
     try {
@@ -593,6 +596,14 @@ function SwitcherApp() {
       modeRef.current = 'terminal';
       setMode('terminal');
     });
+
+    // Account count decides whether the ⌥⌘+Enter picker hint is shown.
+    window.electronAPI
+      .getAccounts()
+      .then((r) => {
+        if (r.ok) setIsMultiAccountUI(((r.accounts || []) as unknown[]).length > 1);
+      })
+      .catch(() => {});
 
     // If initial mode is sessions (from URL hash), fetch sessions immediately
     if (initialMode === 'sessions') {
@@ -1567,7 +1578,9 @@ function SwitcherApp() {
               title="\u2325\u2318+Enter: choose the account first"
               style={{ fontSize: '11px', color: '#666', paddingRight: '8px', whiteSpace: 'nowrap' }}
             >
-              {'\u2318+Enter: New Claude'}
+              {isMultiAccountUI
+                ? '\u2318+Enter: New Claude \u00b7 \u2325\u2318+Enter: pick account'
+                : '\u2318+Enter: New Claude'}
             </div>
           ),
           Option: (props) => OptionUI(props, onDeleteClick, (path: string) => {


### PR DESCRIPTION
## Summary

Batch 2c-lite (follows #125): **pick the account when launching a new Claude session** — `⌥⌘+Enter` on a project opens a small account picker; plain `⌘+Enter` stays exactly as before.

Design decision (per discussion): the picker is behind a **modifier**, never forced — quick-launch speed is preserved, and "which account does bare `⌘+Enter` use" remains the **global default** (`codev account default` / Settings → Accounts), which shipped with 2e. Cross-account **resume** is deliberately NOT here — a session's transcript lives in its own account's `projects/` dir, so "resume under another account" must be an explicit **copy-fork** (Batch 3), never a link.

## Behavior

| Gesture | Result |
|---|---|
| `⌘+Enter` | unchanged — instant launch under the **global default** (bare `claude` → dispatcher) |
| `⇧+Enter` | unchanged — launch in the CodeV embedded terminal |
| **`⌥⌘+Enter`** | **account picker** (↑↓ / Enter / Esc, click and hover work; `default` marker + email shown) → launches with explicit `CLAUDE_CONFIG_DIR='…' command claude` (dispatcher bypassed, mirroring resume) |
| `⌥⌘+Enter`, single account / no registry | no picker — falls through to a normal launch |

## Implementation

- `launchNewClaudeSession(projectPath, terminalApp, terminalMode, accountLabel?)` — with a label, builds the env-prefixed `command claude` (single-quote-escaped); without, bare `claude` as before. VS Code (#121) and the embedded codev terminal ignore the label (logged).
- IPC `launch-new-claude-session` + preload + types gain the optional label.
- Renderer: `launchClaudeRef` gains `'external-pick'`; the picker overlay reuses the `data-settings-panel` escape hatch so the global focus-stealing click handler leaves it alone; `Esc` closes only the picker (stopPropagation).
- Hover tooltip on the "⌘+Enter: New Claude" hint advertises `⌥⌘+Enter`.

## Also in this PR (grew during review/testing)

- **Fix (critical, review-caught):** `runCommandInTerminal` now receives `claudeCmd` as its 2nd arg — Ghostty/cmux build their launch scripts from it, so the picked account's env prefix reaches those terminals too (iTerm2/Terminal.app were unaffected; resume already did this).
- **Live hint:** the search-bar hint shows `· ⌥⌘+Enter: pick account` **only for multi-account setups**, and refreshes after account add/remove (same-window `codev-accounts-changed` event + window-focus re-check) — no app restart (user-reported).
- **Picker error handling:** if `getAccounts()` fails, the picker logs and aborts instead of silently launching the global default.
- **Tab completion for `claude <name>`:** `claude <TAB>` completes account labels; registered only when nothing else completes `claude` (`_comps` guard — a future official completion wins automatically); other argument positions keep zsh's default file completion (`_files` fallback).
- **UI polish:** removed react-select's default `IndicatorSeparator` (the stray `|` before the hint; user-reported).
- **Docs:** README gains a full Multi-Account section (setup, shell-command table, `codev account` CLI table, UI map, common-scenarios table, session-probe gotcha); design doc marks 2e as shipped and **drops 2d** (folder→account auto-switch) — one folder legitimately hosts sessions from multiple accounts, so a folder default would guess wrong exactly where it matters; 2e global default + this picker cover the need.

### Account naming & rename (second wave, from a design session on the name/folder model)

The model: an account is a **name → config-folder mapping**. The name is a mutable label; the folder is fixed at creation and **never moves** (credentials are keyed by the folder path). The UI now states this and shows `· folder: …` on a row whenever they diverge.

- **`codev account rename <old> <new>`** (CLI) + a per-row **Rename** button (UI, inline input with Enter/Esc). This is also the only way to rename the anchor (`~/.claude`) account, which can't be removed.
- **First-ever add asks what to name your existing `~/.claude` login** — a prefilled field (`main`) in the UI, `--anchor-name` in the CLI — replacing the old auto-assumed `personal` (the machine's first login may well be a company account).
- **`default` is a reserved name** (add/rename/anchor-name all reject it): it already denotes the dispatcher's global-default concept (the `default` badge, `codev account default`), so an account named `default` would permanently collide.
- **One folder = one account**: registering an already-registered folder under a second name is rejected (a duplicate mapping would double-scan sessions and blur attribution).
- Remove notice now shows the kept **folder** and folder-suffix reattach guidance (after a rename, "add the old label back" would have targeted a wrong, empty folder).
- Follow-ups filed: onboarding niceties (detect existing config dirs & one-click register, wrapper-collision warning) in #127; cross-account copy-fork resume in #128. Internal `isDefault`→`isAnchor` schema rename agreed as a separate small PR.

## How to test (needs `yarn make`)

1. Projects tab → select a project → **`⌥⌘+Enter`** → picker shows personal/work (+default marker, emails).
2. Pick **work** → terminal opens a new claude in that project → `!command claude auth status` shows the work identity (`!claude auth status` would show the global default — see #123's gotcha).
3. Pick **personal** → same check, personal identity.
4. `Esc` closes the picker; clicking the dimmed backdrop closes it; `⌘+Enter` still launches instantly.
5. Settings → Accounts: add/remove an account → the search-bar hint switches between the short/long form **without restarting** the app; the stray `|` before the hint is gone.
6. Shell: after `codev account regenerate` + a new shell, `claude w<TAB>` completes `work`; `claude -p ./<TAB>` still completes files.
7. If you use Ghostty or cmux as the session terminal: pick an account via `⌥⌘+Enter` and verify with `!command claude auth status` (this path carried the critical fix).
8. Rename: per-row **Rename** → change a name and back (folder shown unchanged via `· folder: …` while diverged); renaming anything to `default` is rejected (reserved).
9. First-add flow (fresh-registry simulation): `cp ~/.config/codev/accounts.json /tmp/bak && rm ~/.config/codev/accounts.json` → Accounts tab shows the anchor-naming field (prefilled `main`) → add a test account → both rows appear (anchor named as chosen). Restore: `cp /tmp/bak ~/.config/codev/accounts.json && codev account regenerate`.

`tsc --noEmit` 0 errors; `yarn test` 18/18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an account picker for new Claude sessions, zsh completion for `claude <TAB>`, and account naming/rename. Improves multi-account safety, external-terminal launches, and docs.

- New Features
  - ⌥⌘+Enter opens an account picker for new sessions; single-account skips. External terminals launch via explicit `CLAUDE_CONFIG_DIR` + `command claude`; a default pick uses `env -u CLAUDE_CONFIG_DIR claude`. The search-bar hint shows the picker shortcut only when multiple accounts exist and updates live.
  - zsh: `claude <TAB>` completes account labels; registers only if no existing `claude` completion; other positions fall back to `_files`.
  - Naming & rename: `codev account rename <old> <new>` and a per-row Rename in the UI. On first add, you choose a name for the existing `~/.claude` account (empty uses a safe default: `main`, or `primary` when the new account is named `main`); `default` is reserved. The UI shows the config folder when name ≠ folder suffix; add explains create‑or‑attach (`~/.claude-<name>`) and rejects duplicate folder mappings.

- Bug Fixes
  - External terminals (Ghostty/cmux): pass the computed `claudeCmd` so the picked account’s env is preserved; explicit default picks clear `CLAUDE_CONFIG_DIR`; the picker aborts on account‑load failure or a stale/removed label.
  - UI/Docs: hide the stray `IndicatorSeparator`; remove is non‑destructive and now shows the kept folder with re‑attach guidance; README and design docs updated (2d dropped; 2c‑lite clarifies the `main`→`primary` fallback).

<sup>Written for commit 0434d2e2a5b4074a3a5c72b9f27cadd54fda99c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/grimmerk/codev/pull/126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-account “account-first” session picker for **⌥⌘+Enter** (keyboard/mouse) with session launch using the selected account; **⌘+Enter** keeps default behavior.
  * Added **`codev account rename <old> <new>`** plus improved account management (anchor options, richer account hints, per-row rename).
  * Added **`claude <TAB>`** label completion and updated shell completion behavior.

* **Bug Fixes**
  * Improved live hint/account updates without restart and refined picker hint text.

* **Documentation**
  * Updated README with Multi-Account Support details and revised Batch 2 phasing guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

