### PR TITLE
refactor(multi-account): registry isDefault -> isAnchor (naming collision fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.81
+
+- Refactor: registry field `isDefault` → `isAnchor` (naming collision fix)
+  - The per-account flag marks the **anchor** (`~/.claude`) account; the *dispatcher default* is the top-level `defaultAccount` — the old name conflated the two (an account could read `isDefault: true` while not being the bare-`claude` default)
+  - Backward compatible: legacy `isDefault` registries are read as-is and migrate to `isAnchor` on the next write; no behavior change
+
 ## 1.0.80
 
 - Feat: multi-account Batch 2c-lite — pick the account when launching a new session

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Refactor: registry field `isDefault` → `isAnchor` (naming collision fix)
   - The per-account flag marks the **anchor** (`~/.claude`) account; the *dispatcher default* is the top-level `defaultAccount` — the old name conflated the two (an account could read `isDefault: true` while not being the bare-`claude` default)
-  - Backward compatible: legacy `isDefault` registries are read as-is and migrate to `isAnchor` on the next write; no behavior change
+  - No compatibility shim: the registry format never shipped in a release, so the key simply changed (a missing flag is inferred from the dir — `~/.claude` is the anchor by definition); no behavior change
 
 ## 1.0.80
 

--- a/docs/multi-account-support-design.md
+++ b/docs/multi-account-support-design.md
@@ -189,7 +189,7 @@ Single source of truth (registry), read by both the shell layer and CodeV:
      "projectMap": { "/Users/me/git/work-repo": "work" }   // §6.H, optional
    }
    // Simplified sketch — each entry also records `configDirEnv`, `identityFile`,
-   // and `isAnchor` (legacy name `isDefault` still read); see §11 for the schema.
+   // and `isAnchor`; see §11 for the full copy-paste schema.
 ```
 
 Launching account X = `CLAUDE_CONFIG_DIR=<X.dir> claude …` **for extra accounts**; the
@@ -548,9 +548,8 @@ Batch 1 ships the *engine*; account setup is manual until the Batch 2 UI/CLI.
 - **Registry** — `~/.config/codev/accounts.json`: one entry per account with
   `label`, `dir`, `configDirEnv` (null for the anchor), `identityFile`, `isAnchor`
   (the ~/.claude anchor flag — NOT the dispatcher default, which is the top-level
-  `defaultAccount`; the legacy field name `isDefault` is still accepted on read and
-  migrated on the next write). The anchor account is `~/.claude` (its `.claude.json`
-  sits at `~/.claude.json`,
+  `defaultAccount`; if omitted it is inferred from the dir). The anchor account is
+  `~/.claude` (its `.claude.json` sits at `~/.claude.json`,
   HOME level — never set `CLAUDE_CONFIG_DIR=~/.claude`, see §3.4). Extra accounts
   live in `~/.claude-<label>`.
 - **Shell** — `~/.config/codev/accounts.sh` (sourced from `~/.zshrc`) defines

--- a/docs/multi-account-support-design.md
+++ b/docs/multi-account-support-design.md
@@ -189,7 +189,7 @@ Single source of truth (registry), read by both the shell layer and CodeV:
      "projectMap": { "/Users/me/git/work-repo": "work" }   // §6.H, optional
    }
    // Simplified sketch — each entry also records `configDirEnv`, `identityFile`,
-   // and `isDefault`; see §11 for the full copy-paste schema.
+   // and `isAnchor` (legacy name `isDefault` still read); see §11 for the schema.
 ```
 
 Launching account X = `CLAUDE_CONFIG_DIR=<X.dir> claude …` **for extra accounts**; the
@@ -546,8 +546,11 @@ No CLI/PATH helper exists today; the hook installer is the reference pattern.
 Batch 1 ships the *engine*; account setup is manual until the Batch 2 UI/CLI.
 
 - **Registry** — `~/.config/codev/accounts.json`: one entry per account with
-  `label`, `dir`, `configDirEnv` (null for the default), `identityFile`, `isDefault`.
-  The default account is `~/.claude` (its `.claude.json` sits at `~/.claude.json`,
+  `label`, `dir`, `configDirEnv` (null for the anchor), `identityFile`, `isAnchor`
+  (the ~/.claude anchor flag — NOT the dispatcher default, which is the top-level
+  `defaultAccount`; the legacy field name `isDefault` is still accepted on read and
+  migrated on the next write). The anchor account is `~/.claude` (its `.claude.json`
+  sits at `~/.claude.json`,
   HOME level — never set `CLAUDE_CONFIG_DIR=~/.claude`, see §3.4). Extra accounts
   live in `~/.claude-<label>`.
 - **Shell** — `~/.config/codev/accounts.sh` (sourced from `~/.zshrc`) defines
@@ -570,8 +573,8 @@ Batch 1 ships the *engine*; account setup is manual until the Batch 2 UI/CLI.
   "version": 1,
   "defaultAccount": "personal",
   "accounts": [
-    { "label": "personal", "dir": "/Users/you/.claude",       "identityFile": "/Users/you/.claude.json",            "configDirEnv": null,                        "isDefault": true },
-    { "label": "work",     "dir": "/Users/you/.claude-work",  "identityFile": "/Users/you/.claude-work/.claude.json", "configDirEnv": "/Users/you/.claude-work", "isDefault": false }
+    { "label": "personal", "dir": "/Users/you/.claude",       "identityFile": "/Users/you/.claude.json",            "configDirEnv": null,                        "isAnchor": true },
+    { "label": "work",     "dir": "/Users/you/.claude-work",  "identityFile": "/Users/you/.claude-work/.claude.json", "configDirEnv": "/Users/you/.claude-work", "isAnchor": false }
   ]
 }
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "CodeV",
   "productName": "CodeV",
-  "version": "1.0.80",
+  "version": "1.0.81",
   "description": "Quick switcher for VS Code, Cursor, and Claude Code sessions",
   "repository": {
     "type": "git",

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -105,12 +105,14 @@ export const getAccounts = (): CodevAccount[] => {
           String(a.dir || path.join(os.homedir(), '.claude')),
         );
         // isAnchor with legacy fallback: old registries wrote `isDefault`;
-        // if both are omitted, infer from the top-level defaultAccount label
-        // (tolerating partial hand-written entries).
+        // if both are omitted (partial hand-written entry), infer from the
+        // dir itself — ~/.claude IS the anchor by definition. Never infer
+        // from defaultAccount: that's the dispatcher target, a different
+        // concept (and would misroute once the default is a non-anchor).
         const isAnchor =
           a.isAnchor ??
           a.isDefault ??
-          (!!raw.defaultAccount && a.label === raw.defaultAccount);
+          path.resolve(dir) === path.join(os.homedir(), '.claude');
         const configDirEnv =
           a.configDirEnv === null || a.configDirEnv === undefined
             ? isAnchor

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -21,10 +21,13 @@ import * as fs from 'fs';
 
 export interface CodevAccount {
   label: string;
-  dir: string; // config dir for session scanning (default account: ~/.claude)
-  configDirEnv: string | null; // CLAUDE_CONFIG_DIR at launch; null => default account (unset)
-  identityFile: string; // .claude.json path (HOME for default, <dir>/.claude.json otherwise)
-  isDefault: boolean;
+  dir: string; // config dir for session scanning (anchor account: ~/.claude)
+  configDirEnv: string | null; // CLAUDE_CONFIG_DIR at launch; null => anchor account (unset)
+  identityFile: string; // .claude.json path (HOME for the anchor, <dir>/.claude.json otherwise)
+  // The anchor is the ~/.claude account — distinct from the GLOBAL DEFAULT
+  // (registry `defaultAccount`, what bare `claude` opens). Historically this
+  // field was called `isDefault`, which conflated the two concepts.
+  isAnchor: boolean;
   email?: string;
   org?: string;
   subscription?: string;
@@ -37,7 +40,8 @@ interface RawAccount {
   dir?: string;
   configDirEnv?: string | null;
   identityFile?: string;
-  isDefault?: boolean;
+  isAnchor?: boolean;
+  isDefault?: boolean; // legacy name for isAnchor (pre-1.0.81 registries)
   email?: string;
   org?: string;
   subscription?: string;
@@ -59,12 +63,12 @@ const REGISTRY_PATH = path.join(
 const expandHome = (p: string): string =>
   p.startsWith('~') ? path.join(os.homedir(), p.slice(1)) : p;
 
-const makeDefaultAccount = (): CodevAccount => ({
+const makeAnchorAccount = (): CodevAccount => ({
   label: 'default',
   dir: path.join(os.homedir(), '.claude'),
   configDirEnv: null,
   identityFile: path.join(os.homedir(), '.claude.json'),
-  isDefault: true,
+  isAnchor: true,
 });
 
 let cached: CodevAccount[] | null = null;
@@ -88,7 +92,7 @@ export const getAccounts = (): CodevAccount[] => {
   let accounts: CodevAccount[];
   try {
     if (!fs.existsSync(REGISTRY_PATH)) {
-      accounts = [makeDefaultAccount()];
+      accounts = [makeAnchorAccount()];
     } else {
       const raw = JSON.parse(
         fs.readFileSync(REGISTRY_PATH, 'utf-8'),
@@ -100,20 +104,22 @@ export const getAccounts = (): CodevAccount[] => {
         const dir = expandHome(
           String(a.dir || path.join(os.homedir(), '.claude')),
         );
-        // Tolerate a partial registry entry: if isDefault is omitted, infer it
-        // from the top-level defaultAccount label.
-        const isDefault =
+        // isAnchor with legacy fallback: old registries wrote `isDefault`;
+        // if both are omitted, infer from the top-level defaultAccount label
+        // (tolerating partial hand-written entries).
+        const isAnchor =
+          a.isAnchor ??
           a.isDefault ??
           (!!raw.defaultAccount && a.label === raw.defaultAccount);
         const configDirEnv =
           a.configDirEnv === null || a.configDirEnv === undefined
-            ? isDefault
+            ? isAnchor
               ? null
               : dir
             : expandHome(String(a.configDirEnv));
         const identityFile = a.identityFile
           ? expandHome(String(a.identityFile))
-          : isDefault
+          : isAnchor
             ? path.join(os.homedir(), '.claude.json')
             : path.join(dir, '.claude.json');
         return {
@@ -121,7 +127,7 @@ export const getAccounts = (): CodevAccount[] => {
           dir,
           configDirEnv,
           identityFile,
-          isDefault,
+          isAnchor,
           email: a.email,
           org: a.org,
           subscription: a.subscription,
@@ -129,12 +135,12 @@ export const getAccounts = (): CodevAccount[] => {
         };
       });
       if (accounts.length === 0) {
-        accounts = [makeDefaultAccount()];
+        accounts = [makeAnchorAccount()];
       }
     }
   } catch (error) {
     console.error('Error reading codev accounts registry:', error);
-    accounts = [makeDefaultAccount()];
+    accounts = [makeAnchorAccount()];
   }
 
   cached = accounts;
@@ -155,12 +161,12 @@ export const getScannableAccounts = (): CodevAccount[] =>
     }
   });
 
-/** Look up an account by label (falls back to the default account). */
+/** Look up an account by label (falls back to the anchor account). */
 export const getAccountByLabel = (label: string | undefined): CodevAccount => {
   const accounts = getAccounts();
   return (
     accounts.find((a) => a.label === label) ||
-    accounts.find((a) => a.isDefault) ||
+    accounts.find((a) => a.isAnchor) ||
     accounts[0]
   );
 };

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -41,7 +41,6 @@ interface RawAccount {
   configDirEnv?: string | null;
   identityFile?: string;
   isAnchor?: boolean;
-  isDefault?: boolean; // legacy name for isAnchor (pre-1.0.81 registries)
   email?: string;
   org?: string;
   subscription?: string;
@@ -104,15 +103,13 @@ export const getAccounts = (): CodevAccount[] => {
         const dir = expandHome(
           String(a.dir || path.join(os.homedir(), '.claude')),
         );
-        // isAnchor with legacy fallback: old registries wrote `isDefault`;
-        // if both are omitted (partial hand-written entry), infer from the
+        // If the flag is omitted (partial hand-written entry), infer from the
         // dir itself — ~/.claude IS the anchor by definition. Never infer
         // from defaultAccount: that's the dispatcher target, a different
         // concept (and would misroute once the default is a non-anchor).
         const isAnchor =
           a.isAnchor ??
-          a.isDefault ??
-          path.resolve(dir) === path.join(os.homedir(), '.claude');
+          (path.resolve(dir) === path.join(os.homedir(), '.claude'));
         const configDirEnv =
           a.configDirEnv === null || a.configDirEnv === undefined
             ? isAnchor

--- a/src/claude-session-utility.ts
+++ b/src/claude-session-utility.ts
@@ -30,7 +30,7 @@ export interface ClaudeSession {
   accountLabel?: string; // codev multi-account: which account this session belongs to
   accountDir?: string; // that account's config dir (session data + enrichment root)
   accountConfigDirEnv?: string | null; // CLAUDE_CONFIG_DIR to set at resume (null = default)
-  accountIsDefault?: boolean; // default account => no CLAUDE_CONFIG_DIR at launch
+  accountIsAnchor?: boolean; // anchor (~/.claude) account => no CLAUDE_CONFIG_DIR at launch
 }
 
 export interface ActiveSessionResult {
@@ -57,7 +57,7 @@ interface SessionAccum {
   accountLabel: string;
   accountDir: string;
   accountConfigDirEnv: string | null;
-  accountIsDefault: boolean;
+  accountIsAnchor: boolean;
 }
 
 const getHistoryPath = (dir: string): string => {
@@ -141,7 +141,7 @@ export const readClaudeSessions = (limit = 100): ClaudeSession[] => {
               accountLabel: account.label,
               accountDir: account.dir,
               accountConfigDirEnv: account.configDirEnv,
-              accountIsDefault: account.isDefault,
+              accountIsAnchor: account.isAnchor,
             });
           }
         } catch {
@@ -172,7 +172,7 @@ export const readClaudeSessions = (limit = 100): ClaudeSession[] => {
       accountLabel: s.accountLabel,
       accountDir: s.accountDir,
       accountConfigDirEnv: s.accountConfigDirEnv,
-      accountIsDefault: s.accountIsDefault,
+      accountIsAnchor: s.accountIsAnchor,
     }));
 
   cachedSessions = allSessions;

--- a/src/cli/account-manager.test.ts
+++ b/src/cli/account-manager.test.ts
@@ -207,9 +207,8 @@ describe('generateAccountsSh', () => {
 });
 
 describe('normalizeRegistry', () => {
-  it('migrates the legacy isDefault field to isAnchor (purely)', () => {
+  it('normalizes shape purely (input untouched)', () => {
     const input = {
-      version: 1,
       defaultAccount: 'work',
       accounts: [
         {
@@ -217,26 +216,24 @@ describe('normalizeRegistry', () => {
           dir: '/u/.claude',
           identityFile: '/u/.claude.json',
           configDirEnv: null,
-          isDefault: true, // legacy name
+          isAnchor: true,
         },
         {
           label: 'work',
           dir: '/u/.claude-work',
           identityFile: '/u/.claude-work/.claude.json',
           configDirEnv: '/u/.claude-work',
-          isDefault: false, // legacy name
+          isAnchor: false,
         },
       ],
     };
     const snapshot = JSON.stringify(input);
     const norm = normalizeRegistry(input);
+    expect(norm.version).toBe(1); // shape default filled in
     expect(norm.accounts[0].isAnchor).toBe(true);
     expect(norm.accounts[1].isAnchor).toBe(false);
-    // legacy key dropped so the migration completes on the next write
-    expect('isDefault' in norm.accounts[0]).toBe(false);
-    // pure: the input object is untouched
+    // pure: the input object is untouched (no version added, no remapping)
     expect(JSON.stringify(input)).toBe(snapshot);
-    // and a legacy registry still generates a correct accounts.sh
     const sh = generateAccountsSh(norm);
     expect(sh).toContain(
       'claude-personal() { env -u CLAUDE_CONFIG_DIR claude "$@"; }',

--- a/src/cli/account-manager.test.ts
+++ b/src/cli/account-manager.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect } from 'vitest';
 
 import {
   generateAccountsSh,
+  normalizeRegistry,
   resolveDefaultLabel,
   type Registry,
 } from './account-manager';
@@ -23,14 +24,14 @@ function reg(overrides: Partial<Registry> = {}): Registry {
         dir: path.join(HOME, '.claude'),
         identityFile: path.join(HOME, '.claude.json'),
         configDirEnv: null,
-        isDefault: true,
+        isAnchor: true,
       },
       {
         label: 'work',
         dir: path.join(HOME, '.claude-work'),
         identityFile: path.join(HOME, '.claude-work', '.claude.json'),
         configDirEnv: path.join(HOME, '.claude-work'),
-        isDefault: false,
+        isAnchor: false,
       },
     ],
     ...overrides,
@@ -82,7 +83,7 @@ describe('generateAccountsSh', () => {
           dir: '/tmp/$(touch pwned)',
           identityFile: '/tmp/x/.claude.json',
           configDirEnv: '/tmp/$(touch pwned)',
-          isDefault: false,
+          isAnchor: false,
         },
       ],
     });
@@ -118,7 +119,7 @@ describe('generateAccountsSh', () => {
           dir: '/tmp/clean',
           identityFile: '/tmp/clean/.claude.json',
           configDirEnv: '/tmp/$(touch pwned)',
-          isDefault: false,
+          isAnchor: false,
         },
       ],
     });
@@ -181,7 +182,7 @@ describe('generateAccountsSh', () => {
           dir: '/tmp/clean',
           identityFile: '/tmp/clean/.claude.json',
           configDirEnv: '/tmp/clean',
-          isDefault: false,
+          isAnchor: false,
         },
       ],
     });
@@ -197,11 +198,46 @@ describe('generateAccountsSh', () => {
           dir: '/tmp/x',
           identityFile: '/tmp/x/.claude.json',
           configDirEnv: '',
-          isDefault: false,
+          isAnchor: false,
         },
       ],
     });
     expect(() => generateAccountsSh(bad)).toThrow(/Invalid account path/);
+  });
+});
+
+describe('normalizeRegistry', () => {
+  it('migrates the legacy isDefault field to isAnchor', () => {
+    const norm = normalizeRegistry({
+      version: 1,
+      defaultAccount: 'work',
+      accounts: [
+        {
+          label: 'personal',
+          dir: '/u/.claude',
+          identityFile: '/u/.claude.json',
+          configDirEnv: null,
+          isDefault: true, // legacy name
+        },
+        {
+          label: 'work',
+          dir: '/u/.claude-work',
+          identityFile: '/u/.claude-work/.claude.json',
+          configDirEnv: '/u/.claude-work',
+          isDefault: false, // legacy name
+        },
+      ],
+    });
+    expect(norm.accounts[0].isAnchor).toBe(true);
+    expect(norm.accounts[1].isAnchor).toBe(false);
+    // legacy key dropped so the migration completes on the next write
+    expect('isDefault' in norm.accounts[0]).toBe(false);
+    // and a legacy registry still generates a correct accounts.sh
+    const sh = generateAccountsSh(norm);
+    expect(sh).toContain(
+      'claude-personal() { env -u CLAUDE_CONFIG_DIR claude "$@"; }',
+    );
+    expect(resolveDefaultLabel(norm)).toBe('work');
   });
 });
 
@@ -210,13 +246,13 @@ describe('resolveDefaultLabel', () => {
     expect(resolveDefaultLabel(reg({ defaultAccount: 'work' }))).toBe('work');
   });
 
-  it('falls back to the isDefault anchor when defaultAccount is missing', () => {
+  it('falls back to the anchor when defaultAccount is missing', () => {
     expect(resolveDefaultLabel(reg({ defaultAccount: undefined }))).toBe(
       'personal',
     );
   });
 
-  it('falls back to the isDefault anchor when defaultAccount is unknown', () => {
+  it('falls back to the anchor when defaultAccount is unknown', () => {
     expect(resolveDefaultLabel(reg({ defaultAccount: 'ghost' }))).toBe(
       'personal',
     );

--- a/src/cli/account-manager.test.ts
+++ b/src/cli/account-manager.test.ts
@@ -207,8 +207,8 @@ describe('generateAccountsSh', () => {
 });
 
 describe('normalizeRegistry', () => {
-  it('migrates the legacy isDefault field to isAnchor', () => {
-    const norm = normalizeRegistry({
+  it('migrates the legacy isDefault field to isAnchor (purely)', () => {
+    const input = {
       version: 1,
       defaultAccount: 'work',
       accounts: [
@@ -227,17 +227,43 @@ describe('normalizeRegistry', () => {
           isDefault: false, // legacy name
         },
       ],
-    });
+    };
+    const snapshot = JSON.stringify(input);
+    const norm = normalizeRegistry(input);
     expect(norm.accounts[0].isAnchor).toBe(true);
     expect(norm.accounts[1].isAnchor).toBe(false);
     // legacy key dropped so the migration completes on the next write
     expect('isDefault' in norm.accounts[0]).toBe(false);
+    // pure: the input object is untouched
+    expect(JSON.stringify(input)).toBe(snapshot);
     // and a legacy registry still generates a correct accounts.sh
     const sh = generateAccountsSh(norm);
     expect(sh).toContain(
       'claude-personal() { env -u CLAUDE_CONFIG_DIR claude "$@"; }',
     );
     expect(resolveDefaultLabel(norm)).toBe('work');
+  });
+
+  it('infers isAnchor from the dir when both flags are absent', () => {
+    const norm = normalizeRegistry({
+      version: 1,
+      accounts: [
+        {
+          label: 'x',
+          dir: path.join(HOME, '.claude'),
+          identityFile: path.join(HOME, '.claude.json'),
+          configDirEnv: null,
+        },
+        {
+          label: 'y',
+          dir: path.join(HOME, '.claude-y'),
+          identityFile: path.join(HOME, '.claude-y', '.claude.json'),
+          configDirEnv: path.join(HOME, '.claude-y'),
+        },
+      ],
+    });
+    expect(norm.accounts[0].isAnchor).toBe(true); // ~/.claude IS the anchor
+    expect(norm.accounts[1].isAnchor).toBe(false);
   });
 });
 

--- a/src/cli/account-manager.ts
+++ b/src/cli/account-manager.ts
@@ -25,8 +25,12 @@ export interface RegistryAccount {
   label: string;
   dir: string; // config dir (session data lives under <dir>/projects, /sessions)
   identityFile: string; // .claude.json path
-  configDirEnv: string | null; // CLAUDE_CONFIG_DIR at launch; null => default account
-  isDefault: boolean; // the anchor ~/.claude account (HOME .claude.json)
+  configDirEnv: string | null; // CLAUDE_CONFIG_DIR at launch; null => anchor account
+  // The anchor is the machine's ~/.claude account (identity at HOME
+  // .claude.json, launched with NO CLAUDE_CONFIG_DIR). Distinct from the
+  // GLOBAL DEFAULT (`defaultAccount` below, what bare `claude` opens) — the
+  // field was historically called `isDefault`, which conflated the two.
+  isAnchor: boolean;
   email?: string;
   org?: string;
   subscription?: string;
@@ -82,8 +86,8 @@ const toTildePath = (p: string): string => {
     : p;
 };
 
-/** Is this dir the special DEFAULT account (~/.claude, HOME .claude.json)? */
-const isDefaultDir = (dir: string): boolean =>
+/** Is this dir the ANCHOR account's (~/.claude, HOME .claude.json)? */
+const isAnchorDir = (dir: string): boolean =>
   path.resolve(expandHome(dir)) === defaultDir();
 
 // Registry dirs get embedded (double-quoted) into the generated accounts.sh and
@@ -126,16 +130,31 @@ function stripUndefined<T extends object>(obj: T): Partial<T> {
 // registry read / write
 // ---------------------------------------------------------------------------
 
+/**
+ * Normalize a parsed registry: legacy entries used `isDefault` for what is
+ * really the ANCHOR flag — accept it, expose `isAnchor`, and drop the old key
+ * (so the migration completes on the next write). Pure, for testability.
+ */
+export function normalizeRegistry(raw: unknown): Registry {
+  const reg = (raw && typeof raw === 'object' ? raw : {}) as Registry;
+  if (!reg.version) reg.version = 1;
+  if (!Array.isArray(reg.accounts)) reg.accounts = [];
+  reg.accounts = reg.accounts.map(
+    (a: RegistryAccount & { isDefault?: boolean }) => {
+      const { isDefault, ...rest } = a;
+      return { ...rest, isAnchor: a.isAnchor ?? isDefault ?? false };
+    },
+  );
+  return reg;
+}
+
 export function readRegistry(): Registry {
   if (!fs.existsSync(REGISTRY_PATH)) {
     // No hardcoded default — the first added account becomes the default, and
     // resolveDefaultLabel falls back to the anchor. Avoids a dangling reference.
     return { version: 1, accounts: [] };
   }
-  const raw = JSON.parse(fs.readFileSync(REGISTRY_PATH, 'utf-8')) as Registry;
-  if (!raw.version) raw.version = 1;
-  if (!Array.isArray(raw.accounts)) raw.accounts = [];
-  return raw;
+  return normalizeRegistry(JSON.parse(fs.readFileSync(REGISTRY_PATH, 'utf-8')));
 }
 
 export function writeRegistry(reg: Registry): void {
@@ -167,7 +186,7 @@ export function resolveDefaultLabel(reg: Registry): string | undefined {
   ) {
     return reg.defaultAccount;
   }
-  const anchor = accounts.find((a) => a.isDefault) || accounts[0];
+  const anchor = accounts.find((a) => a.isAnchor) || accounts[0];
   return anchor ? anchor.label : undefined;
 }
 
@@ -326,7 +345,7 @@ export function generateAccountsSh(reg: Registry): string {
     // bash-sourceable; registration is guarded for zsh + a loaded compinit.
     const allLabels = accounts.map((a) => a.label).join(' ');
     const removable = accounts
-      .filter((a) => !a.isDefault)
+      .filter((a) => !a.isAnchor)
       .map((a) => a.label)
       .join(' ');
     L.push('');
@@ -454,12 +473,12 @@ export function addAccount(
       `That folder is already registered as "${dupDir.label}" (${dir})`,
     );
   }
-  const isDefault = isDefaultDir(dir);
+  const isAnchor = isAnchorDir(dir);
   // Fresh registry + adding an EXTRA account: seed the anchor (~/.claude)
   // account first, so the machine's existing default install stays registered
   // and keeps the global default (instead of it silently moving to a
   // brand-new, not-yet-logged-in account).
-  if (reg.accounts.length === 0 && !isDefault) {
+  if (reg.accounts.length === 0 && !isAnchor) {
     // The anchor's name is the USER'S choice (UI first-add field / CLI
     // --anchor-name); 'main' is only the neutral prefill — never assume
     // 'personal' (the machine's first login may well be a company account).
@@ -481,20 +500,20 @@ export function addAccount(
       dir: defaultDir(),
       identityFile: anchorIdentity,
       configDirEnv: null,
-      isDefault: true,
+      isAnchor: true,
       ...readIdentity(anchorIdentity),
     });
     reg.defaultAccount = anchorLabel;
   }
-  const identityFile = isDefault
+  const identityFile = isAnchor
     ? path.join(os.homedir(), '.claude.json')
     : path.join(dir, '.claude.json');
   const entry: RegistryAccount = {
     label,
     dir,
     identityFile,
-    configDirEnv: isDefault ? null : dir,
-    isDefault,
+    configDirEnv: isAnchor ? null : dir,
+    isAnchor,
     loggedIn: false,
     ...readIdentity(identityFile),
   };
@@ -516,7 +535,7 @@ export function removeAccount(label: string): string | undefined {
   if (reg.accounts.length === 1) {
     throw new Error('Refusing to remove the only configured account');
   }
-  if (reg.accounts[idx].isDefault) {
+  if (reg.accounts[idx].isAnchor) {
     throw new Error(
       `"${label}" is the anchor (~/.claude) account and can't be unregistered`,
     );
@@ -526,7 +545,7 @@ export function removeAccount(label: string): string | undefined {
   // removing a non-default account leaves the default untouched.
   let reassignedDefault: string | undefined;
   if (reg.defaultAccount === label) {
-    const anchor = reg.accounts.find((a) => a.isDefault) || reg.accounts[0];
+    const anchor = reg.accounts.find((a) => a.isAnchor) || reg.accounts[0];
     reg.defaultAccount = anchor.label;
     reassignedDefault = anchor.label;
   }

--- a/src/cli/account-manager.ts
+++ b/src/cli/account-manager.ts
@@ -131,22 +131,18 @@ function stripUndefined<T extends object>(obj: T): Partial<T> {
 // ---------------------------------------------------------------------------
 
 /**
- * Normalize a parsed registry: legacy entries used `isDefault` for what is
- * really the ANCHOR flag — accept it, expose `isAnchor`, and drop the old key
- * (so the migration completes on the next write). Pure, for testability.
+ * Normalize a parsed registry (shape defaults + anchor inference for partial
+ * hand-written entries). Pure — returns a normalized copy.
  */
 export function normalizeRegistry(raw: unknown): Registry {
   const src = (raw && typeof raw === 'object' ? raw : {}) as Registry;
   const accounts = (Array.isArray(src.accounts) ? src.accounts : []).map(
-    (a: RegistryAccount & { isDefault?: boolean }) => {
-      const { isDefault, ...rest } = a;
-      return {
-        ...rest,
-        // When both flags are absent (partial hand-written entry), the dir is
-        // the ground truth: ~/.claude IS the anchor by definition.
-        isAnchor: a.isAnchor ?? isDefault ?? isAnchorDir(String(a.dir || '')),
-      };
-    },
+    (a: RegistryAccount) => ({
+      ...a,
+      // When the flag is absent (partial hand-written entry), the dir is the
+      // ground truth: ~/.claude IS the anchor by definition.
+      isAnchor: a.isAnchor ?? isAnchorDir(String(a.dir || '')),
+    }),
   );
   return { ...src, version: src.version || 1, accounts };
 }

--- a/src/cli/account-manager.ts
+++ b/src/cli/account-manager.ts
@@ -136,16 +136,19 @@ function stripUndefined<T extends object>(obj: T): Partial<T> {
  * (so the migration completes on the next write). Pure, for testability.
  */
 export function normalizeRegistry(raw: unknown): Registry {
-  const reg = (raw && typeof raw === 'object' ? raw : {}) as Registry;
-  if (!reg.version) reg.version = 1;
-  if (!Array.isArray(reg.accounts)) reg.accounts = [];
-  reg.accounts = reg.accounts.map(
+  const src = (raw && typeof raw === 'object' ? raw : {}) as Registry;
+  const accounts = (Array.isArray(src.accounts) ? src.accounts : []).map(
     (a: RegistryAccount & { isDefault?: boolean }) => {
       const { isDefault, ...rest } = a;
-      return { ...rest, isAnchor: a.isAnchor ?? isDefault ?? false };
+      return {
+        ...rest,
+        // When both flags are absent (partial hand-written entry), the dir is
+        // the ground truth: ~/.claude IS the anchor by definition.
+        isAnchor: a.isAnchor ?? isDefault ?? isAnchorDir(String(a.dir || '')),
+      };
     },
   );
-  return reg;
+  return { ...src, version: src.version || 1, accounts };
 }
 
 export function readRegistry(): Registry {

--- a/src/cli/codev-account.ts
+++ b/src/cli/codev-account.ts
@@ -61,7 +61,7 @@ function printList(): void {
       ? a.email || '(logged in)'
       : '(not logged in — run: claude ' + a.label + ')';
     const tags = [
-      a.isDefault ? 'anchor ~/.claude' : `CLAUDE_CONFIG_DIR=${a.dir}`,
+      a.isAnchor ? 'anchor ~/.claude' : `CLAUDE_CONFIG_DIR=${a.dir}`,
     ];
     console.log(`  ${star} ${a.label.padEnd(pad)}  ${who}`);
     console.log(`      ${tags.join('  ')}`);
@@ -95,8 +95,8 @@ function main(): number {
       const wasFresh = manager.readRegistry().accounts.length === 0;
       const acct = manager.addAccount(label as string, { dir, anchorName });
       console.log(`✓ Added "${acct.label}"  (${acct.dir})`);
-      if (wasFresh && !acct.isDefault) {
-        const anchor = manager.listAccounts().find((x) => x.isDefault);
+      if (wasFresh && !acct.isAnchor) {
+        const anchor = manager.listAccounts().find((x) => x.isAnchor);
         if (anchor) {
           console.log(
             `  Your existing ~/.claude login is registered as "${anchor.label}" (change: codev account rename ${anchor.label} <new>)`,

--- a/src/electron-api.d.ts
+++ b/src/electron-api.d.ts
@@ -6,7 +6,7 @@ type IpcCallback = (event: Electron.IpcRendererEvent, ...args: any[]) => void;
 interface CodevAccountInfo {
   label: string;
   dir: string;
-  isDefault: boolean; // the anchor ~/.claude account
+  isAnchor: boolean; // the anchor ~/.claude account (not the dispatcher default)
   isCurrentDefault: boolean; // what bare `claude` resolves to
   email?: string;
   org?: string;

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -98,7 +98,7 @@ const PopupDefaultExample = ({
   type AccountRow = {
     label: string;
     dir: string;
-    isDefault: boolean;
+    isAnchor: boolean;
     isCurrentDefault: boolean;
     email?: string;
     loggedIn?: boolean;
@@ -929,7 +929,7 @@ const PopupDefaultExample = ({
                           Set default
                         </button>
                       )}
-                      {!a.isDefault && (
+                      {!a.isAnchor && (
                         <button
                           style={{ ...smallButtonStyle, color: THEME.button.warning }}
                           onClick={() => handleRemoveAccount(a.label)}

--- a/src/switcher-ui.tsx
+++ b/src/switcher-ui.tsx
@@ -1384,7 +1384,7 @@ function SwitcherApp() {
                             </span>
                           );
                         })()}
-                        {session.accountLabel && !session.accountIsDefault && (
+                        {session.accountLabel && !session.accountIsAnchor && (
                           <span
                             style={{
                               fontSize: '9px',


### PR DESCRIPTION
## Summary

**PR-A of the Batch 3 plan**: rename the registry's per-account `isDefault` field to **`isAnchor`** — a pure naming refactor with backward-compatible reads, no behavior change.

## Why

The multi-account system has three separate concepts, and two of them shared a name:

| Concept | What it is | Registry representation |
|---|---|---|
| **Anchor** | the `~/.claude` account (identity at HOME `.claude.json`, launched with no `CLAUDE_CONFIG_DIR`, can't be removed) | per-account flag — **was `isDefault`**, now `isAnchor` |
| **Default** | what bare `claude` opens (the dispatcher target, `default` badge, `codev account default`) | top-level `defaultAccount` |
| **Name** | mutable label | `label` |

With `codev account default work`, the anchor's entry literally read `isDefault: true` while **not** being the default — actively misleading for anyone reading the registry or the code.

## What changed

- **Schema**: entries now write `isAnchor`. **No compatibility shim**: the registry format never shipped in a release — the only registry in existence (the author's local one) was migrated by hand, so a legacy-read path would have been dead weight. `normalizeRegistry()` (new, pure, exported, tested) still provides shape defaults + **dir-based anchor inference** for partial hand-written entries (`~/.claude` *is* the anchor by definition).
- **Reader** (`src/accounts.ts`): `CodevAccount.isAnchor`; a missing flag is inferred **from the dir** — never from `defaultAccount`, which is the dispatcher target and a different concept (the old inference would misroute once the default is a non-anchor account); `makeDefaultAccount` → `makeAnchorAccount`.
- **Session tag**: `accountIsDefault` → `accountIsAnchor` (utility + Sessions-tab badge condition).
- **UI/CLI/types**: popup Remove-gating, CLI `list` anchor tag + fresh-add note, `CodevAccountInfo`, `isDefaultDir` → `isAnchorDir`, docs §4/§11 schema examples.
- `isCurrentDefault` (the dispatcher concept in `listAccounts`) is intentionally **unchanged** — that name is correct.

## Verification

- `tsc --noEmit` 0 errors; `yarn test` **20/20** (+2: pure shape normalization with input-untouched assertion; dir-based anchor inference).
- Live sanity: `yarn account list` against the real (migrated) registry reads correctly (anchor + extra account, `*` on the right default).

## Notes

- No UI/UX change; single-account users unaffected (no registry → nothing to touch).
- Review round already folded in: `normalizeRegistry` made truly pure (returns a copy), and both readers unified on dir-based inference so they can't disagree on anchor identity.
- Sets up Batch 3 (share engine), whose logic is anchor-centric — building it on the misleading name would have cemented the confusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the per-account registry flag from isDefault to isAnchor to distinguish the anchor account (~/.claude) from the dispatcher default. Backward compatible via a pure normalizer that also infers the anchor from the dir when missing; no behavior change.

- **Refactors**
  - Registry schema now writes `isAnchor`; `normalizeRegistry` accepts legacy `isDefault`, drops it on next write, and returns a normalized copy.
  - Readers updated: `CodevAccount.isAnchor`, `makeAnchorAccount`; missing flag inferred from the dir (`~/.claude`), not from `defaultAccount`.
  - Session/UI/CLI: `accountIsDefault` → `accountIsAnchor`, Remove gating uses the anchor flag, CLI list tag updated, `CodevAccountInfo` uses `isAnchor`, `isDefaultDir` → `isAnchorDir`.
  - Docs, tests, and CHANGELOG updated; version bumped to 1.0.81.

- **Migration**
  - No manual steps. Legacy registries with `isDefault` are read and rewritten as `isAnchor` on next write.

<sup>Written for commit e0ec0e3725a159827395c86755d7bbe44fc678b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/grimmerk/codev/pull/129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved account handling by clearly distinguishing the anchor account from the selected default account.
  * Account listings, session details, and account switching now consistently identify the anchor account.
* **Bug Fixes**
  * Existing registries using the legacy account flag are automatically migrated when saved.
  * Added safer fallback behavior when account configuration is missing, empty, or invalid.
* **Documentation**
  * Updated account configuration guidance and examples to reflect the new terminology.
* **Release**
  * Version 1.0.81 is now available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
