### PR TITLE
feat(multi-account): cross-account sharing — engine + CLI + UI (Batch 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.0.82
+
+- Feat: multi-account Batch 3 — cross-account sharing (share engine + CLI + UI)
+  - Share the anchor's `CLAUDE.md` / `skills/` / `commands/` with other accounts: **Link** (symlink, stays in sync) or **Copy** (independent fork), per item
+  - Never silently overwrites: existing content is backed up to `.codev-bak-<ts>` first; **Unlink & restore** is a true undo, plain Unlink loses nothing (source untouched)
+  - UI: per-account **Sharing** panel (status + Link/Copy/Unlink buttons; recognizes pre-existing hand-made symlinks); CLI: `codev account share|unshare` (`--entry` for single skills/commands entries, `--restore-backup`/`--keep-copy` on unshare)
+  - `codev account sync-settings <name> <keys>` copies `statusLine`/`model`/`effortLevel`/`theme` from the anchor (hooks/`enabledPlugins`/permissions deliberately excluded)
+  - `plugins/` is NOT symlink-shared (per-account install registry with absolute paths — verified by experiment); real-fs integration tests cover the engine (12 cases)
+
 ## 1.0.81
 
 - Refactor: registry field `isDefault` → `isAnchor` (naming collision fix)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@
 - Feat: multi-account Batch 3 — cross-account sharing (share engine + CLI + UI)
   - Share the anchor's `CLAUDE.md` / `skills/` / `commands/` with other accounts: **Link** (symlink, stays in sync) or **Copy** (independent fork), per item
   - Never silently overwrites: existing content is backed up to `.codev-bak-<ts>` first; **Unlink & restore** is a true undo, plain Unlink loses nothing (source untouched)
-  - UI: per-account **Sharing** panel (status + Link/Copy/Unlink buttons; recognizes pre-existing hand-made symlinks); CLI: `codev account share|unshare` (`--entry` for single skills/commands entries, `--restore-backup`/`--keep-copy` on unshare)
-  - `codev account sync-settings <name> <keys>` copies `statusLine`/`model`/`effortLevel`/`theme` from the anchor (hooks/`enabledPlugins`/permissions deliberately excluded)
-  - `plugins/` is NOT symlink-shared (per-account install registry with absolute paths — verified by experiment); real-fs integration tests cover the engine (12 cases)
+  - UI: per-account **Sharing ▸/▾** panel (per-item status + Link/Copy/Unlink/**Unlink & restore**; recognizes pre-existing hand-made symlinks; refreshes on window focus so terminal-side file changes show up live) plus one-click **settings-key sync buttons** (`statusLine`/`model`/`effortLevel`/`theme`)
+  - CLI: `codev account share|unshare` (`--entry` for single skills/commands entries, `--restore-backup`/`--keep-copy` on unshare) and `codev account sync-settings <name> <keys>` (same allowlist; hooks/`enabledPlugins`/permissions deliberately excluded)
+  - `plugins/` is NOT symlink-shared (per-account install registry with absolute paths — verified by experiment)
+  - Hardening from review: unshare validates the restore/keep-copy source *before* unlinking; keep-copy stages to a unique temp first (no TOCTOU); backup names uniquified beyond 1s precision; malformed settings.json fails with the path; real-fs integration tests cover the engine (14 cases, 35 total)
 
 ## 1.0.81
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The `codev` command runs the CLI **bundled inside CodeV.app** (`ELECTRON_RUN_AS_
 
 **Cross-account sharing** (also in the UI: each account row's **Sharing** button):
 
-Share the anchor's global files with other accounts — per item, three choices: **Link** (symlink; one file, stays in sync, edits from either side land in the same place), **Copy** (independent fork), or skip. Never silently overwrites: existing content is backed up to a timestamped `.codev-bak-*` sibling first, which also makes **Unlink & restore** a true undo. Plain Unlink loses nothing (the anchor's copy is untouched; re-link anytime).
+Share the anchor's global files with other accounts — per item, three choices: **Link** (symlink; one file, stays in sync, edits from either side land in the same place), **Copy** (independent fork), or skip. Never silently overwrites: existing content is backed up to a timestamped `.codev-bak-*` sibling first, which also makes **Unlink & restore** a true undo. Plain Unlink loses nothing (the anchor's copy is untouched; re-link anytime). The panel also has one-click **settings-key sync** buttons (`statusLine` / `model` / `effortLevel` / `theme`) and refreshes automatically when the window regains focus (so terminal-side file changes show up live).
 
 | Item | Shareable? | How |
 |------|------------|-----|
@@ -117,7 +117,7 @@ Share the anchor's global files with other accounts — per item, three choices:
 
 | Where | What |
 |-------|------|
-| Settings → Accounts | List/add/remove/rename accounts, set the global default, install shell integration, per-account **Sharing** panel |
+| Settings → Accounts | List/add/remove/rename accounts, set the global default, install shell integration, per-account **Sharing** panel (link/copy/unlink + settings-key sync) |
 | Sessions tab | Sessions from all accounts with account badges; resume uses each session's own account |
 | Projects tab: `⌥⌘+Enter` | Pick the account for a new session (`⌘+Enter` stays instant, under the global default). Account override applies to external terminals (iTerm2, Terminal.app, Ghostty, cmux); VS Code ([#121](https://github.com/grimmerk/codev/issues/121)) and the embedded Term tab ignore it |
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The **default account** can be launched three equivalent ways: bare `claude`, `c
 | `codev account install` / `uninstall` | Add / remove the `~/.zshrc` source block |
 | `codev account share <name>` | Sharing status for that account (claude-md / skills / commands) |
 | `codev account share <name> <item> --link\|--copy [--entry E]` | Share the anchor's item — link stays in sync, copy forks |
-| `codev account unshare <name> <item> [--restore-backup\|--keep-copy]` | Remove the link; `--restore-backup` = true undo, `--keep-copy` = keep a fork |
+| `codev account unshare <name> <item> [--entry E] [--restore-backup\|--keep-copy]` | Remove the link; `--restore-backup` = true undo, `--keep-copy` = keep a fork |
 | `codev account sync-settings <name> <key...>` | Copy settings keys from the anchor (`statusLine`, `model`, `effortLevel`, `theme`) |
 
 > **Add is just a mapping.** `add <name>` registers *name → config folder* (default `~/.claude-<name>` — that folder **is** the account's `CLAUDE_CONFIG_DIR`). Claude Code itself creates and fills the folder on first login (`claude <name>`). One folder = one account: registering an already-registered folder under a second name is rejected.
@@ -110,7 +110,7 @@ Share the anchor's global files with other accounts — per item, three choices:
 |------|------------|-----|
 | Global `CLAUDE.md`, `skills/`, `commands/` | ✅ | Link or Copy (verified: Claude Code follows symlinks) |
 | `statusLine` / `model` / `effortLevel` / `theme` | ✅ | `sync-settings` (per-key copy — they live in `settings.json`) |
-| `plugins/` | ❌ | Per-account install state with absolute paths — sync the `enabledPlugins` need via `sync-settings`-style per-account installs instead |
+| `plugins/` | ❌ | Per-account install state with absolute paths. Install and enable plugins in each account separately — `enabledPlugins` is per-account and **not** a syncable key |
 | `.claude.json`, session data, hooks | ❌ | Identity / live-written / installed per-dir by CodeV |
 
 **In the CodeV UI:**

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ The **default account** can be launched three equivalent ways: bare `claude`, `c
 | `codev account regenerate` (`regen`) | Rewrite `accounts.sh` from the registry |
 | `codev account show` (`preview`) | Dry-run print of the generated `accounts.sh` |
 | `codev account install` / `uninstall` | Add / remove the `~/.zshrc` source block |
+| `codev account share <name>` | Sharing status for that account (claude-md / skills / commands) |
+| `codev account share <name> <item> --link\|--copy [--entry E]` | Share the anchor's item — link stays in sync, copy forks |
+| `codev account unshare <name> <item> [--restore-backup\|--keep-copy]` | Remove the link; `--restore-backup` = true undo, `--keep-copy` = keep a fork |
+| `codev account sync-settings <name> <key...>` | Copy settings keys from the anchor (`statusLine`, `model`, `effortLevel`, `theme`) |
 
 > **Add is just a mapping.** `add <name>` registers *name → config folder* (default `~/.claude-<name>` — that folder **is** the account's `CLAUDE_CONFIG_DIR`). Claude Code itself creates and fills the folder on first login (`claude <name>`). One folder = one account: registering an already-registered folder under a second name is rejected.
 >
@@ -98,11 +102,22 @@ The **default account** can be launched three equivalent ways: bare `claude`, `c
 
 The `codev` command runs the CLI **bundled inside CodeV.app** (`ELECTRON_RUN_AS_NODE`) — no system Node, no sudo, no PATH edits. CodeV refreshes `accounts.sh` on every launch, so moving or renaming the app self-heals. (Not available in MAS builds — sandboxed.)
 
+**Cross-account sharing** (also in the UI: each account row's **Sharing** button):
+
+Share the anchor's global files with other accounts — per item, three choices: **Link** (symlink; one file, stays in sync, edits from either side land in the same place), **Copy** (independent fork), or skip. Never silently overwrites: existing content is backed up to a timestamped `.codev-bak-*` sibling first, which also makes **Unlink & restore** a true undo. Plain Unlink loses nothing (the anchor's copy is untouched; re-link anytime).
+
+| Item | Shareable? | How |
+|------|------------|-----|
+| Global `CLAUDE.md`, `skills/`, `commands/` | ✅ | Link or Copy (verified: Claude Code follows symlinks) |
+| `statusLine` / `model` / `effortLevel` / `theme` | ✅ | `sync-settings` (per-key copy — they live in `settings.json`) |
+| `plugins/` | ❌ | Per-account install state with absolute paths — sync the `enabledPlugins` need via `sync-settings`-style per-account installs instead |
+| `.claude.json`, session data, hooks | ❌ | Identity / live-written / installed per-dir by CodeV |
+
 **In the CodeV UI:**
 
 | Where | What |
 |-------|------|
-| Settings → Accounts | List/add/remove accounts, set the global default, install shell integration |
+| Settings → Accounts | List/add/remove/rename accounts, set the global default, install shell integration, per-account **Sharing** panel |
 | Sessions tab | Sessions from all accounts with account badges; resume uses each session's own account |
 | Projects tab: `⌥⌘+Enter` | Pick the account for a new session (`⌘+Enter` stays instant, under the global default). Account override applies to external terminals (iTerm2, Terminal.app, Ghostty, cmux); VS Code ([#121](https://github.com/grimmerk/codev/issues/121)) and the embedded Term tab ignore it |
 

--- a/docs/multi-account-support-design.md
+++ b/docs/multi-account-support-design.md
@@ -488,8 +488,14 @@ and **(d)** for CodeV, backed by the same `projectMap` in the registry so both a
     only for *account-explicit* operations (resuming a session under its own account,
     picker launches) via `command claude` / explicit env; the plain ⌘+Enter new-session
     path deliberately stays on bare `claude` so the dispatcher's global default applies.
-- **Batch 3 — later:** cross-account symlink reuse of global files
-  (CLAUDE.md / skills / commands / plugins / settings, §5).
+- **Batch 3 — ✅ core shipped** (branch `feat/account-sharing`; PR-A = the isAnchor
+  refactor #129): share engine (`src/cli/share-manager.ts`, path-based + real-fs
+  tmpdir tests) + `codev account share/unshare/sync-settings` + per-account UI
+  Sharing panel. Link/copy/skip per item; `.codev-bak-*` collision backups double as
+  the unshare restore path. `plugins/` excluded by experiment (per-account install
+  registry with absolute installPaths); its need is covered by per-account installs +
+  the `enabledPlugins` settings key. Remaining backlog: #127 (detect existing config
+  dirs + one-click register), #128 (copy-fork resume), #121 (VS Code).
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "CodeV",
   "productName": "CodeV",
-  "version": "1.0.81",
+  "version": "1.0.82",
   "description": "Quick switcher for VS Code, Cursor, and Claude Code sessions",
   "repository": {
     "type": "git",

--- a/src/cli/account-manager.test.ts
+++ b/src/cli/account-manager.test.ts
@@ -152,6 +152,9 @@ describe('generateAccountsSh', () => {
     );
     // item + key completion at position 5
     expect(sh).toContain('share|unshare) compadd claude-md skills commands ;;');
+    expect(sh).toContain(
+      'sync-settings) compadd statusLine model effortLevel theme ;;',
+    );
   });
 
   it('completes account labels for `claude <TAB>` without clobbering', () => {

--- a/src/cli/account-manager.test.ts
+++ b/src/cli/account-manager.test.ts
@@ -143,11 +143,15 @@ describe('generateAccountsSh', () => {
     expect(sh).toContain('_codev() {');
     expect(sh).toContain('compdef _codev codev');
     expect(sh).toContain(
-      'compadd list add default remove rm rename regenerate show install uninstall help',
+      'compadd list add default remove rm rename share unshare sync-settings regenerate show install uninstall help',
     );
     expect(sh).toContain('default|rename) compadd personal work ;;');
-    // anchor (personal) is not removable
-    expect(sh).toContain('remove|rm) compadd work ;;');
+    // anchor (personal) is not removable/shareable-to
+    expect(sh).toContain(
+      'remove|rm|share|unshare|sync-settings) compadd work ;;',
+    );
+    // item + key completion at position 5
+    expect(sh).toContain('share|unshare) compadd claude-md skills commands ;;');
   });
 
   it('completes account labels for `claude <TAB>` without clobbering', () => {

--- a/src/cli/account-manager.ts
+++ b/src/cli/account-manager.ts
@@ -176,6 +176,11 @@ export function readIdentity(identityFile: string): Identity {
   }
 }
 
+/** An account's settings.json lives inside its config dir (anchor included). */
+export const getSettingsPath = (
+  account: Pick<RegistryAccount, 'dir'>,
+): string => path.join(expandHome(account.dir), 'settings.json');
+
 /** Label bare `claude` maps to (defaultAccount if valid, else the anchor). */
 export function resolveDefaultLabel(reg: Registry): string | undefined {
   const accounts = reg.accounts || [];
@@ -354,12 +359,23 @@ export function generateAccountsSh(reg: Registry): string {
     L.push('    compadd account');
     L.push('  elif (( CURRENT == 3 )) && [ "${words[2]}" = "account" ]; then');
     L.push(
-      '    compadd list add default remove rm rename regenerate show install uninstall help',
+      '    compadd list add default remove rm rename share unshare sync-settings regenerate show install uninstall help',
     );
     L.push('  elif (( CURRENT == 4 )) && [ "${words[2]}" = "account" ]; then');
     L.push('    case "${words[3]}" in');
     if (allLabels) L.push(`      default|rename) compadd ${allLabels} ;;`);
-    if (removable) L.push(`      remove|rm) compadd ${removable} ;;`);
+    if (removable) {
+      L.push(
+        `      remove|rm|share|unshare|sync-settings) compadd ${removable} ;;`,
+      );
+    }
+    L.push('    esac');
+    L.push('  elif (( CURRENT == 5 )) && [ "${words[2]}" = "account" ]; then');
+    L.push('    case "${words[3]}" in');
+    L.push('      share|unshare) compadd claude-md skills commands ;;');
+    L.push(
+      '      sync-settings) compadd statusLine model effortLevel theme ;;',
+    );
     L.push('    esac');
     L.push('  fi');
     L.push('}');

--- a/src/cli/codev-account.ts
+++ b/src/cli/codev-account.ts
@@ -14,7 +14,11 @@
  * `codev account` binary on PATH is wired up in Batch 2b.
  */
 
+import * as os from 'os';
+
 import * as manager from './account-manager';
+import * as share from './share-manager';
+import type { ShareItemKey, ShareState } from './share-manager';
 
 const USAGE = `codev account — manage CodeV multi-account registry
 
@@ -28,6 +32,17 @@ Usage:
   codev account default <label>      Set which account bare \`claude\` resolves to
   codev account remove <label>       Unregister an account (leaves its dir on disk)
   codev account rename <old> <new>   Rename an account's label (folder is not moved)
+  codev account share <name>         Sharing status (claude-md / skills / commands)
+  codev account share <name> <item> --link|--copy [--entry E]
+                                     Share the anchor's <item> into <name>
+                                     (link = stay in sync; copy = independent fork)
+  codev account unshare <name> <item> [--entry E] [--restore-backup|--keep-copy]
+                                     Remove the link (source untouched);
+                                     --restore-backup = undo a share that displaced
+                                     own content; --keep-copy = keep a real copy
+  codev account sync-settings <name> <key...>
+                                     Copy settings.json keys from the anchor
+                                     (allowed: statusLine, model, effortLevel, theme)
   codev account regenerate           Rewrite ~/.config/codev/accounts.sh from the registry
   codev account show                 Print the generated accounts.sh (dry run, writes nothing)
   codev account install              Add the source line to ~/.zshrc (idempotent)
@@ -43,6 +58,49 @@ function reloadHint(): void {
 function getFlag(args: string[], name: string): string | undefined {
   const i = args.indexOf(name);
   return i >= 0 ? args[i + 1] : undefined;
+}
+
+function assertShareItem(item: string): asserts item is ShareItemKey {
+  if (!(share.SHARE_ITEMS as string[]).includes(item)) {
+    throw new Error(
+      `Unknown item "${item}" — one of: ${share.SHARE_ITEMS.join(', ')}`,
+    );
+  }
+}
+
+const tildify = (p: string): string =>
+  p.startsWith(os.homedir()) ? `~${p.slice(os.homedir().length)}` : p;
+
+function describeShareState(s: ShareState): string {
+  switch (s.kind) {
+    case 'none':
+      return 'none';
+    case 'own':
+      return 'own (not shared)';
+    case 'linked':
+      return `linked → ${tildify(s.to)}`;
+    case 'broken-link':
+      return `BROKEN link → ${tildify(s.to)}`;
+    case 'mixed':
+      return `mixed (${s.linked.length} linked: ${s.linked.join(', ')}; ${s.own.length} own)`;
+  }
+}
+
+function printShareStatus(name: string): void {
+  const status = share.shareStatusFor(name);
+  console.log(`Sharing status for "${name}" (source = anchor ~/.claude):`);
+  for (const item of share.SHARE_ITEMS) {
+    const st = status[item];
+    const backups = st.backups.length
+      ? `   [${st.backups.length} backup${st.backups.length > 1 ? 's' : ''}]`
+      : '';
+    console.log(
+      `  ${item.padEnd(10)} ${describeShareState(st.state)}${backups}`,
+    );
+  }
+  console.log(
+    "  share with: codev account share <name> <item> --link (or --copy); plugins/settings keys via 'sync-settings'",
+  );
 }
 
 function printList(): void {
@@ -139,6 +197,103 @@ function main(): number {
       console.log(`✓ Unregistered "${label}" (its dir is left on disk)`);
       if (newDefault) console.log(`  default account is now "${newDefault}"`);
       reloadHint();
+      return 0;
+    }
+
+    case 'share': {
+      const entry = getFlag(rest, '--entry');
+      const skip = new Set<number>();
+      const ei = rest.indexOf('--entry');
+      if (ei >= 0) skip.add(ei + 1);
+      const positional = rest.filter(
+        (a, i) => !a.startsWith('-') && !skip.has(i),
+      );
+      const [name, item] = positional;
+      if (!name) {
+        console.error('share: <name> is required');
+        return 1;
+      }
+      if (!item) {
+        printShareStatus(name);
+        return 0;
+      }
+      assertShareItem(item);
+      const mode = rest.includes('--copy')
+        ? ('copy' as const)
+        : rest.includes('--link')
+          ? ('link' as const)
+          : null;
+      if (!mode) {
+        console.error('share: pass --link (stay in sync) or --copy (fork)');
+        return 1;
+      }
+      const r = share.shareFor(name, item, mode, entry);
+      console.log(
+        `✓ ${mode === 'link' ? 'Linked' : 'Copied'} ${item}${entry ? `/${entry}` : ''} → ${r.target}`,
+      );
+      if (r.backedUpTo) {
+        console.log(
+          `  previous content backed up: ${r.backedUpTo} (unshare --restore-backup undoes this)`,
+        );
+      }
+      console.log('  new Claude Code sessions pick this up immediately');
+      return 0;
+    }
+
+    case 'unshare': {
+      const entry = getFlag(rest, '--entry');
+      const skip = new Set<number>();
+      const ei = rest.indexOf('--entry');
+      if (ei >= 0) skip.add(ei + 1);
+      const positional = rest.filter(
+        (a, i) => !a.startsWith('-') && !skip.has(i),
+      );
+      const [name, item] = positional;
+      if (!name || !item) {
+        console.error('unshare: <name> and <item> are required');
+        return 1;
+      }
+      assertShareItem(item);
+      const r = share.unshareFor(
+        name,
+        item,
+        {
+          restoreBackup: rest.includes('--restore-backup'),
+          keepCopy: rest.includes('--keep-copy'),
+        },
+        entry,
+      );
+      console.log(`✓ Unshared ${item}${entry ? `/${entry}` : ''}`);
+      if (r.restoredFrom) {
+        console.log(`  restored your previous content from ${r.restoredFrom}`);
+      } else if (rest.includes('--keep-copy')) {
+        console.log('  kept an independent copy of the shared content');
+      } else {
+        console.log(
+          '  the source is untouched — share --link again to re-attach',
+        );
+      }
+      return 0;
+    }
+
+    case 'sync-settings': {
+      const [name, ...keys] = rest.filter((a) => !a.startsWith('-'));
+      if (!name || keys.length === 0) {
+        console.error(
+          `sync-settings: <name> and at least one key are required (allowed: ${share.SYNCABLE_SETTINGS_KEYS.join(', ')})`,
+        );
+        return 1;
+      }
+      const r = share.syncSettingsFor(name, keys);
+      if (r.copied.length) {
+        console.log(`✓ Copied from the anchor: ${r.copied.join(', ')}`);
+      }
+      if (r.missingInSource.length) {
+        console.log(
+          `  not set on the anchor (skipped): ${r.missingInSource.join(', ')}`,
+        );
+      }
+      console.log('  applies to NEW Claude Code sessions of that account');
       return 0;
     }
 

--- a/src/cli/codev-account.ts
+++ b/src/cli/codev-account.ts
@@ -218,15 +218,16 @@ function main(): number {
         return 0;
       }
       assertShareItem(item);
-      const mode = rest.includes('--copy')
-        ? ('copy' as const)
-        : rest.includes('--link')
-          ? ('link' as const)
-          : null;
-      if (!mode) {
-        console.error('share: pass --link (stay in sync) or --copy (fork)');
+      const wantLink = rest.includes('--link');
+      const wantCopy = rest.includes('--copy');
+      if (wantLink === wantCopy) {
+        // neither, or ambiguously both
+        console.error(
+          'share: pass exactly one of --link (stay in sync) or --copy (fork)',
+        );
         return 1;
       }
+      const mode = wantCopy ? ('copy' as const) : ('link' as const);
       const r = share.shareFor(name, item, mode, entry);
       console.log(
         `✓ ${mode === 'link' ? 'Linked' : 'Copied'} ${item}${entry ? `/${entry}` : ''} → ${r.target}`,

--- a/src/cli/share-manager.test.ts
+++ b/src/cli/share-manager.test.ts
@@ -164,6 +164,32 @@ describe('unshareItem', () => {
     );
   });
 
+  it('a failed restore-backup leaves the link untouched', () => {
+    const source = path.join(anchorDir, 'CLAUDE.md');
+    const target = path.join(accountDir, 'CLAUDE.md');
+    write(source, 'x');
+    shareItem(source, target, 'link'); // no own content displaced → no backup
+
+    expect(() => unshareItem(target, { restoreBackup: true })).toThrow(
+      /No .*backup/,
+    );
+    // validation happens BEFORE unlinking — the share is still intact
+    expect(getShareState(target)).toEqual({ kind: 'linked', to: source });
+  });
+
+  it('rapid re-shares get unique backup names (1s timestamp collision)', () => {
+    const source = path.join(anchorDir, 'CLAUDE.md');
+    const target = path.join(accountDir, 'CLAUDE.md');
+    write(source, 'anchor');
+    write(target, 'own v1');
+    shareItem(source, target, 'link');
+    unshareItem(target);
+    write(target, 'own v2');
+    shareItem(source, target, 'link'); // same second → must not clobber bak 1
+
+    expect(listBackups(target)).toHaveLength(2);
+  });
+
   it("refuses to unshare the account's own real file", () => {
     const target = path.join(accountDir, 'CLAUDE.md');
     write(target, 'own');

--- a/src/cli/share-manager.test.ts
+++ b/src/cli/share-manager.test.ts
@@ -69,9 +69,9 @@ describe('shareItem / getShareState', () => {
     shareItem(source, target, 'copy');
     expect(getShareState(target).kind).toBe('own');
     fs.writeFileSync(path.join(target, 'my-skill', 'SKILL.md'), 'forked');
-    expect(fs.readFileSync(path.join(source, 'my-skill', 'SKILL.md'), 'utf-8')).toBe(
-      'v1',
-    );
+    expect(
+      fs.readFileSync(path.join(source, 'my-skill', 'SKILL.md'), 'utf-8'),
+    ).toBe('v1');
   });
 
   it('links a whole dir and recognizes a pre-existing hand-made link', () => {
@@ -177,7 +177,10 @@ describe('syncSettingsKeys', () => {
     const dst = path.join(accountDir, 'settings.json');
     write(
       src,
-      JSON.stringify({ statusLine: { type: 'command', command: 'x' }, hooks: {} }),
+      JSON.stringify({
+        statusLine: { type: 'command', command: 'x' },
+        hooks: {},
+      }),
     );
     write(dst, JSON.stringify({ theme: 'dark', hooks: { keep: true } }));
 
@@ -188,6 +191,16 @@ describe('syncSettingsKeys', () => {
     expect(out.statusLine.command).toBe('x');
     expect(out.theme).toBe('dark'); // untouched
     expect(out.hooks).toEqual({ keep: true }); // untouched
+  });
+
+  it('fails with an actionable message on malformed settings JSON', () => {
+    const src = path.join(anchorDir, 'settings.json');
+    const dst = path.join(accountDir, 'settings.json');
+    write(src, '{}');
+    write(dst, '{not json');
+    expect(() => syncSettingsKeys(src, dst, ['statusLine'])).toThrow(
+      /Malformed JSON in .*settings\.json/,
+    );
   });
 
   it('rejects non-allowlisted keys (hooks stay per-account)', () => {

--- a/src/cli/share-manager.test.ts
+++ b/src/cli/share-manager.test.ts
@@ -1,0 +1,201 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  getShareState,
+  listBackups,
+  shareItem,
+  syncSettingsKeys,
+  unshareItem,
+} from './share-manager';
+
+// Real-fs integration tests under a per-test tmpdir — the engine is
+// path-based precisely so it can be exercised against actual symlinks.
+let root: string;
+let anchorDir: string;
+let accountDir: string;
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'codev-share-'));
+  anchorDir = path.join(root, 'anchor');
+  accountDir = path.join(root, 'account');
+  fs.mkdirSync(anchorDir, { recursive: true });
+  fs.mkdirSync(accountDir, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+const write = (p: string, content: string) => {
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, content);
+};
+
+describe('shareItem / getShareState', () => {
+  it('links a file and reports linked with the resolved target', () => {
+    const source = path.join(anchorDir, 'CLAUDE.md');
+    const target = path.join(accountDir, 'CLAUDE.md');
+    write(source, 'global rules');
+
+    const r = shareItem(source, target, 'link');
+    expect(r.backedUpTo).toBeUndefined();
+    expect(fs.readFileSync(target, 'utf-8')).toBe('global rules');
+    expect(getShareState(target)).toEqual({ kind: 'linked', to: source });
+  });
+
+  it('backs up an existing own file before linking (never silent overwrite)', () => {
+    const source = path.join(anchorDir, 'CLAUDE.md');
+    const target = path.join(accountDir, 'CLAUDE.md');
+    write(source, 'anchor version');
+    write(target, 'my own version');
+
+    const r = shareItem(source, target, 'link');
+    expect(r.backedUpTo).toBeDefined();
+    expect(fs.readFileSync(r.backedUpTo as string, 'utf-8')).toBe(
+      'my own version',
+    );
+    expect(getShareState(target).kind).toBe('linked');
+    expect(listBackups(target)).toHaveLength(1);
+  });
+
+  it('copy mode forks: mutating the copy does not touch the source', () => {
+    const source = path.join(anchorDir, 'skills');
+    const target = path.join(accountDir, 'skills');
+    write(path.join(source, 'my-skill', 'SKILL.md'), 'v1');
+
+    shareItem(source, target, 'copy');
+    expect(getShareState(target).kind).toBe('own');
+    fs.writeFileSync(path.join(target, 'my-skill', 'SKILL.md'), 'forked');
+    expect(fs.readFileSync(path.join(source, 'my-skill', 'SKILL.md'), 'utf-8')).toBe(
+      'v1',
+    );
+  });
+
+  it('links a whole dir and recognizes a pre-existing hand-made link', () => {
+    const source = path.join(anchorDir, 'skills');
+    const target = path.join(accountDir, 'skills');
+    write(path.join(source, 'a', 'SKILL.md'), 'x');
+    // hand-made link (what the user already has on their machine)
+    fs.symlinkSync(source, target);
+
+    expect(getShareState(target)).toEqual({ kind: 'linked', to: source });
+    // re-sharing over an existing link replaces the pointer, no backup needed
+    const r = shareItem(source, target, 'link');
+    expect(r.backedUpTo).toBeUndefined();
+    expect(getShareState(target).kind).toBe('linked');
+  });
+
+  it('reports mixed for a real dir containing per-entry links', () => {
+    const source = path.join(anchorDir, 'skills');
+    const target = path.join(accountDir, 'skills');
+    write(path.join(source, 'shared-skill', 'SKILL.md'), 'x');
+    write(path.join(target, 'private-skill', 'SKILL.md'), 'y');
+    shareItem(
+      path.join(source, 'shared-skill'),
+      path.join(target, 'shared-skill'),
+      'link',
+    );
+
+    const state = getShareState(target);
+    expect(state.kind).toBe('mixed');
+    if (state.kind === 'mixed') {
+      expect(state.linked).toEqual(['shared-skill']);
+      expect(state.own).toEqual(['private-skill']);
+    }
+  });
+
+  it('detects a broken link', () => {
+    const source = path.join(anchorDir, 'CLAUDE.md');
+    const target = path.join(accountDir, 'CLAUDE.md');
+    write(source, 'x');
+    shareItem(source, target, 'link');
+    fs.rmSync(source);
+    expect(getShareState(target)).toEqual({
+      kind: 'broken-link',
+      to: source,
+    });
+  });
+});
+
+describe('unshareItem', () => {
+  it('plain unlink removes the pointer and leaves the source intact', () => {
+    const source = path.join(anchorDir, 'CLAUDE.md');
+    const target = path.join(accountDir, 'CLAUDE.md');
+    write(source, 'keep me');
+    shareItem(source, target, 'link');
+
+    unshareItem(target);
+    expect(getShareState(target).kind).toBe('none');
+    expect(fs.readFileSync(source, 'utf-8')).toBe('keep me');
+  });
+
+  it('restore-backup is a true undo of a share that displaced own content', () => {
+    const source = path.join(anchorDir, 'CLAUDE.md');
+    const target = path.join(accountDir, 'CLAUDE.md');
+    write(source, 'anchor version');
+    write(target, 'my own version');
+    shareItem(source, target, 'link');
+
+    const r = unshareItem(target, { restoreBackup: true });
+    expect(r.restoredFrom).toBeDefined();
+    expect(getShareState(target).kind).toBe('own');
+    expect(fs.readFileSync(target, 'utf-8')).toBe('my own version');
+    expect(listBackups(target)).toHaveLength(0); // consumed
+  });
+
+  it('keep-copy materializes the shared content as an own copy', () => {
+    const source = path.join(anchorDir, 'skills');
+    const target = path.join(accountDir, 'skills');
+    write(path.join(source, 'a', 'SKILL.md'), 'shared');
+    shareItem(source, target, 'link');
+
+    unshareItem(target, { keepCopy: true });
+    expect(getShareState(target).kind).toBe('own');
+    expect(fs.readFileSync(path.join(target, 'a', 'SKILL.md'), 'utf-8')).toBe(
+      'shared',
+    );
+    // now independent
+    fs.writeFileSync(path.join(target, 'a', 'SKILL.md'), 'mine');
+    expect(fs.readFileSync(path.join(source, 'a', 'SKILL.md'), 'utf-8')).toBe(
+      'shared',
+    );
+  });
+
+  it("refuses to unshare the account's own real file", () => {
+    const target = path.join(accountDir, 'CLAUDE.md');
+    write(target, 'own');
+    expect(() => unshareItem(target)).toThrow(/own file/);
+  });
+});
+
+describe('syncSettingsKeys', () => {
+  it('copies allowlisted keys and reports missing ones', () => {
+    const src = path.join(anchorDir, 'settings.json');
+    const dst = path.join(accountDir, 'settings.json');
+    write(
+      src,
+      JSON.stringify({ statusLine: { type: 'command', command: 'x' }, hooks: {} }),
+    );
+    write(dst, JSON.stringify({ theme: 'dark', hooks: { keep: true } }));
+
+    const r = syncSettingsKeys(src, dst, ['statusLine', 'model']);
+    expect(r.copied).toEqual(['statusLine']);
+    expect(r.missingInSource).toEqual(['model']);
+    const out = JSON.parse(fs.readFileSync(dst, 'utf-8'));
+    expect(out.statusLine.command).toBe('x');
+    expect(out.theme).toBe('dark'); // untouched
+    expect(out.hooks).toEqual({ keep: true }); // untouched
+  });
+
+  it('rejects non-allowlisted keys (hooks stay per-account)', () => {
+    const src = path.join(anchorDir, 'settings.json');
+    const dst = path.join(accountDir, 'settings.json');
+    write(src, '{}');
+    expect(() => syncSettingsKeys(src, dst, ['hooks'])).toThrow(
+      /not a syncable key/,
+    );
+  });
+});

--- a/src/cli/share-manager.ts
+++ b/src/cli/share-manager.ts
@@ -233,12 +233,16 @@ export function syncSettingsKeys(
       );
     }
   }
-  const source = fs.existsSync(sourceSettingsPath)
-    ? JSON.parse(fs.readFileSync(sourceSettingsPath, 'utf-8'))
-    : {};
-  const target = fs.existsSync(targetSettingsPath)
-    ? JSON.parse(fs.readFileSync(targetSettingsPath, 'utf-8'))
-    : {};
+  const readJson = (p: string): Record<string, unknown> => {
+    if (!fs.existsSync(p)) return {};
+    try {
+      return JSON.parse(fs.readFileSync(p, 'utf-8'));
+    } catch (e) {
+      throw new Error(`Malformed JSON in ${p}: ${(e as Error).message}`);
+    }
+  };
+  const source = readJson(sourceSettingsPath);
+  const target = readJson(targetSettingsPath);
   const copied: string[] = [];
   const missingInSource: string[] = [];
   for (const k of keys) {

--- a/src/cli/share-manager.ts
+++ b/src/cli/share-manager.ts
@@ -52,13 +52,19 @@ export interface ShareStatus {
 // path-based core (tmpdir-testable)
 // ---------------------------------------------------------------------------
 
-/** Timestamped backup sibling: `<target>.codev-bak-<ts>`. */
-const backupName = (targetPath: string): string =>
-  `${targetPath}.codev-bak-${new Date()
+/** Timestamped backup sibling: `<target>.codev-bak-<ts>` (uniquified — the
+ * timestamp has 1s precision, so rapid re-shares get a numeric suffix). */
+const backupName = (targetPath: string): string => {
+  const base = `${targetPath}.codev-bak-${new Date()
     .toISOString()
     .replace(/[:.]/g, '-')
     .replace('T', '_')
     .slice(0, 19)}`;
+  let candidate = base;
+  let i = 1;
+  while (fs.existsSync(candidate)) candidate = `${base}-${i++}`;
+  return candidate;
+};
 
 /** Existing backups for a target, newest first. */
 export function listBackups(targetPath: string): string[] {
@@ -187,22 +193,28 @@ export function unshareItem(
     path.dirname(targetPath),
     fs.readlinkSync(targetPath),
   );
-  fs.unlinkSync(targetPath);
 
-  if (opts.keepCopy) {
-    if (!fs.existsSync(resolved)) {
-      throw new Error(`Link target is gone, nothing to copy: ${resolved}`);
+  // Validate the requested replacement BEFORE removing the link, so a failed
+  // restore/keep-copy leaves the share untouched instead of half-undone.
+  let newestBackup: string | undefined;
+  if (opts.keepCopy && !fs.existsSync(resolved)) {
+    throw new Error(`Link target is gone, nothing to copy: ${resolved}`);
+  }
+  if (opts.restoreBackup) {
+    [newestBackup] = listBackups(targetPath);
+    if (!newestBackup) {
+      throw new Error(`No .codev-bak-* backup found for ${targetPath}`);
     }
+  }
+
+  fs.unlinkSync(targetPath);
+  if (opts.keepCopy) {
     fs.cpSync(resolved, targetPath, { recursive: true });
     return {};
   }
-  if (opts.restoreBackup) {
-    const [newest] = listBackups(targetPath);
-    if (!newest) {
-      throw new Error(`No .codev-bak-* backup found for ${targetPath}`);
-    }
-    fs.renameSync(newest, targetPath);
-    return { restoredFrom: newest };
+  if (opts.restoreBackup && newestBackup) {
+    fs.renameSync(newestBackup, targetPath);
+    return { restoredFrom: newestBackup };
   }
   return {};
 }
@@ -302,8 +314,10 @@ export function itemPathsFor(
     if (item === 'claude-md') {
       throw new Error('--entry only applies to skills/commands');
     }
-    if (entry.includes('/') || entry.startsWith('.')) {
-      throw new Error(`Invalid entry name "${entry}"`);
+    if (entry.includes('/') || entry.startsWith('.') || entry.startsWith('-')) {
+      throw new Error(
+        `Invalid entry name "${entry}" (a leading "-" usually means misordered flags)`,
+      );
     }
     return {
       source: path.join(expand(anchor.dir), rel, entry),

--- a/src/cli/share-manager.ts
+++ b/src/cli/share-manager.ts
@@ -211,7 +211,12 @@ export function unshareItem(
     // Copy to a temp sibling BEFORE unlinking — if the copy fails (e.g. the
     // source vanishes mid-operation), the link stays intact; no TOCTOU hole
     // between the existence check and the copy.
-    const tmp = `${targetPath}.codev-tmp-${process.pid}`;
+    // Unique, non-existing temp per operation — a stale leftover (crashed
+    // run) must not be merged into by cpSync and materialized as the copy.
+    let tmp = `${targetPath}.codev-tmp-${process.pid}`;
+    for (let i = 1; fs.existsSync(tmp); i++) {
+      tmp = `${targetPath}.codev-tmp-${process.pid}-${i}`;
+    }
     try {
       fs.cpSync(resolved, tmp, { recursive: true });
     } catch (e) {

--- a/src/cli/share-manager.ts
+++ b/src/cli/share-manager.ts
@@ -207,11 +207,23 @@ export function unshareItem(
     }
   }
 
-  fs.unlinkSync(targetPath);
   if (opts.keepCopy) {
-    fs.cpSync(resolved, targetPath, { recursive: true });
+    // Copy to a temp sibling BEFORE unlinking — if the copy fails (e.g. the
+    // source vanishes mid-operation), the link stays intact; no TOCTOU hole
+    // between the existence check and the copy.
+    const tmp = `${targetPath}.codev-tmp-${process.pid}`;
+    try {
+      fs.cpSync(resolved, tmp, { recursive: true });
+    } catch (e) {
+      fs.rmSync(tmp, { recursive: true, force: true });
+      throw e;
+    }
+    fs.unlinkSync(targetPath);
+    fs.renameSync(tmp, targetPath);
     return {};
   }
+
+  fs.unlinkSync(targetPath);
   if (opts.restoreBackup && newestBackup) {
     fs.renameSync(newestBackup, targetPath);
     return { restoredFrom: newestBackup };

--- a/src/cli/share-manager.ts
+++ b/src/cli/share-manager.ts
@@ -1,0 +1,370 @@
+/**
+ * Cross-account sharing engine (Batch 3).
+ *
+ * Shares the anchor account's global files with other accounts via symlinks
+ * (stay in sync) or copies (fork). Mechanism verified live: Claude Code
+ * follows symlinks for `skills/<name>` entries, whole `skills/`/`commands/`
+ * dirs, and the global `CLAUDE.md` (design doc §5).
+ *
+ * Policy (§5):
+ *   - NEVER silently overwrite: an existing real file/dir is renamed to a
+ *     timestamped `.codev-bak-*` sibling before linking/copying — which also
+ *     makes unshare fully reversible (restore-backup).
+ *   - Per item, three choices: link (sync) / copy (fork) / skip.
+ *   - `.claude.json`, session data, and `plugins/` are deliberately NOT
+ *     shareable (identity, live-written state, per-account install registry
+ *     with absolute paths). Plugins' need is covered by sync-settings
+ *     (`enabledPlugins` stays per-account).
+ *
+ * Core functions are PATH-BASED (no registry coupling) so they get real-fs
+ * integration tests under os.tmpdir(); thin registry-aware wrappers sit at
+ * the bottom.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { getSettingsPath, readRegistry } from './account-manager';
+import type { RegistryAccount } from './account-manager';
+
+export type ShareItemKey = 'claude-md' | 'skills' | 'commands';
+
+export const SHARE_ITEMS: ShareItemKey[] = ['claude-md', 'skills', 'commands'];
+
+/** Relative path of a share item inside a config dir. */
+const itemRelPath = (item: ShareItemKey): string =>
+  item === 'claude-md' ? 'CLAUDE.md' : item;
+
+export type ShareState =
+  | { kind: 'none' } // target doesn't exist
+  | { kind: 'own' } // the account's own real file/dir
+  | { kind: 'linked'; to: string } // symlink (to = resolved target)
+  | { kind: 'broken-link'; to: string } // symlink whose target is gone
+  | { kind: 'mixed'; linked: string[]; own: string[] }; // dir with per-entry links
+
+export interface ShareStatus {
+  state: ShareState;
+  backups: string[]; // newest first, absolute paths
+}
+
+// ---------------------------------------------------------------------------
+// path-based core (tmpdir-testable)
+// ---------------------------------------------------------------------------
+
+/** Timestamped backup sibling: `<target>.codev-bak-<ts>`. */
+const backupName = (targetPath: string): string =>
+  `${targetPath}.codev-bak-${new Date()
+    .toISOString()
+    .replace(/[:.]/g, '-')
+    .replace('T', '_')
+    .slice(0, 19)}`;
+
+/** Existing backups for a target, newest first. */
+export function listBackups(targetPath: string): string[] {
+  const parent = path.dirname(targetPath);
+  const prefix = `${path.basename(targetPath)}.codev-bak-`;
+  try {
+    return fs
+      .readdirSync(parent)
+      .filter((n) => n.startsWith(prefix))
+      .sort()
+      .reverse()
+      .map((n) => path.join(parent, n));
+  } catch {
+    return [];
+  }
+}
+
+export function getShareState(targetPath: string): ShareState {
+  let st: fs.Stats;
+  try {
+    st = fs.lstatSync(targetPath);
+  } catch {
+    return { kind: 'none' };
+  }
+  if (st.isSymbolicLink()) {
+    const to = fs.readlinkSync(targetPath);
+    const resolved = path.resolve(path.dirname(targetPath), to);
+    return fs.existsSync(resolved)
+      ? { kind: 'linked', to: resolved }
+      : { kind: 'broken-link', to: resolved };
+  }
+  if (st.isDirectory()) {
+    // Distinguish an own dir from one with per-entry links inside.
+    const linked: string[] = [];
+    const own: string[] = [];
+    for (const entry of fs.readdirSync(targetPath)) {
+      if (entry.startsWith('.')) continue;
+      try {
+        (fs.lstatSync(path.join(targetPath, entry)).isSymbolicLink()
+          ? linked
+          : own
+        ).push(entry);
+      } catch {
+        /* races are fine — status is advisory */
+      }
+    }
+    if (linked.length > 0) return { kind: 'mixed', linked, own };
+  }
+  return { kind: 'own' };
+}
+
+export function getShareStatus(targetPath: string): ShareStatus {
+  return { state: getShareState(targetPath), backups: listBackups(targetPath) };
+}
+
+/**
+ * Share source → target. `link` keeps the account in sync (one file, both
+ * ways); `copy` forks. An existing real target is renamed to a `.codev-bak-*`
+ * sibling first (never `ln -sf`, never silent overwrite); an existing symlink
+ * is just replaced (a pointer needs no backup).
+ */
+export function shareItem(
+  sourcePath: string,
+  targetPath: string,
+  mode: 'link' | 'copy',
+): { backedUpTo?: string } {
+  if (!fs.existsSync(sourcePath)) {
+    throw new Error(`Source does not exist: ${sourcePath}`);
+  }
+  if (path.resolve(sourcePath) === path.resolve(targetPath)) {
+    throw new Error('Source and target are the same path');
+  }
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+
+  let backedUpTo: string | undefined;
+  let st: fs.Stats | undefined;
+  try {
+    st = fs.lstatSync(targetPath);
+  } catch {
+    /* target absent */
+  }
+  if (st) {
+    if (st.isSymbolicLink()) {
+      fs.unlinkSync(targetPath);
+    } else {
+      backedUpTo = backupName(targetPath);
+      fs.renameSync(targetPath, backedUpTo);
+    }
+  }
+
+  if (mode === 'link') {
+    fs.symlinkSync(sourcePath, targetPath);
+  } else {
+    fs.cpSync(sourcePath, targetPath, { recursive: true });
+  }
+  return { backedUpTo };
+}
+
+/**
+ * Unshare a linked target. Zero data loss by itself (a symlink is just a
+ * pointer; the source stays intact — re-linking restores it any time).
+ *   - default: remove the link (target becomes absent)
+ *   - restoreBackup: additionally restore the newest `.codev-bak-*` sibling
+ *     (true undo of the share that created it)
+ *   - keepCopy: replace the link with a real copy of the shared content
+ */
+export function unshareItem(
+  targetPath: string,
+  opts: { restoreBackup?: boolean; keepCopy?: boolean } = {},
+): { restoredFrom?: string } {
+  if (opts.restoreBackup && opts.keepCopy) {
+    throw new Error('restoreBackup and keepCopy are mutually exclusive');
+  }
+  let st: fs.Stats;
+  try {
+    st = fs.lstatSync(targetPath);
+  } catch {
+    throw new Error(`Not shared (nothing at ${targetPath})`);
+  }
+  if (!st.isSymbolicLink()) {
+    throw new Error(
+      `Not a link: ${targetPath} is the account's own file/dir — nothing to unshare`,
+    );
+  }
+  const resolved = path.resolve(
+    path.dirname(targetPath),
+    fs.readlinkSync(targetPath),
+  );
+  fs.unlinkSync(targetPath);
+
+  if (opts.keepCopy) {
+    if (!fs.existsSync(resolved)) {
+      throw new Error(`Link target is gone, nothing to copy: ${resolved}`);
+    }
+    fs.cpSync(resolved, targetPath, { recursive: true });
+    return {};
+  }
+  if (opts.restoreBackup) {
+    const [newest] = listBackups(targetPath);
+    if (!newest) {
+      throw new Error(`No .codev-bak-* backup found for ${targetPath}`);
+    }
+    fs.renameSync(newest, targetPath);
+    return { restoredFrom: newest };
+  }
+  return {};
+}
+
+// ---------------------------------------------------------------------------
+// settings per-key sync
+// ---------------------------------------------------------------------------
+
+/** Keys that make sense to copy across accounts. Hooks are installed per-dir
+ * by CodeV; enabledPlugins belongs to each account's plugin state;
+ * permissions are security-sensitive — all deliberately excluded. */
+export const SYNCABLE_SETTINGS_KEYS = [
+  'statusLine',
+  'model',
+  'effortLevel',
+  'theme',
+] as const;
+
+export function syncSettingsKeys(
+  sourceSettingsPath: string,
+  targetSettingsPath: string,
+  keys: string[],
+): { copied: string[]; missingInSource: string[] } {
+  for (const k of keys) {
+    if (!(SYNCABLE_SETTINGS_KEYS as readonly string[]).includes(k)) {
+      throw new Error(
+        `"${k}" is not a syncable key (allowed: ${SYNCABLE_SETTINGS_KEYS.join(', ')})`,
+      );
+    }
+  }
+  const source = fs.existsSync(sourceSettingsPath)
+    ? JSON.parse(fs.readFileSync(sourceSettingsPath, 'utf-8'))
+    : {};
+  const target = fs.existsSync(targetSettingsPath)
+    ? JSON.parse(fs.readFileSync(targetSettingsPath, 'utf-8'))
+    : {};
+  const copied: string[] = [];
+  const missingInSource: string[] = [];
+  for (const k of keys) {
+    if (source[k] === undefined) {
+      missingInSource.push(k);
+    } else {
+      target[k] = source[k];
+      copied.push(k);
+    }
+  }
+  fs.mkdirSync(path.dirname(targetSettingsPath), { recursive: true });
+  fs.writeFileSync(
+    targetSettingsPath,
+    JSON.stringify(target, null, 2) + '\n',
+    'utf-8',
+  );
+  return { copied, missingInSource };
+}
+
+// ---------------------------------------------------------------------------
+// registry-aware wrappers
+// ---------------------------------------------------------------------------
+
+function requireAccounts(label: string): {
+  account: RegistryAccount;
+  anchor: RegistryAccount;
+} {
+  const reg = readRegistry();
+  const account = reg.accounts.find((a) => a.label === label);
+  if (!account) throw new Error(`No account "${label}"`);
+  const anchor = reg.accounts.find((a) => a.isAnchor);
+  if (!anchor) throw new Error('No anchor (~/.claude) account registered');
+  if (account.isAnchor) {
+    throw new Error(
+      'That IS the anchor account — sharing goes from the anchor to others',
+    );
+  }
+  return { account, anchor };
+}
+
+const expand = (p: string): string =>
+  p.startsWith('~') ? path.join(os.homedir(), p.slice(1)) : p;
+
+export function itemPathsFor(
+  label: string,
+  item: ShareItemKey,
+  entry?: string,
+): { source: string; target: string } {
+  if (!SHARE_ITEMS.includes(item)) {
+    throw new Error(
+      `Unknown share item "${item}" — one of: ${SHARE_ITEMS.join(', ')}`,
+    );
+  }
+  const { account, anchor } = requireAccounts(label);
+  const rel = itemRelPath(item);
+  if (entry) {
+    if (item === 'claude-md') {
+      throw new Error('--entry only applies to skills/commands');
+    }
+    if (entry.includes('/') || entry.startsWith('.')) {
+      throw new Error(`Invalid entry name "${entry}"`);
+    }
+    return {
+      source: path.join(expand(anchor.dir), rel, entry),
+      target: path.join(expand(account.dir), rel, entry),
+    };
+  }
+  return {
+    source: path.join(expand(anchor.dir), rel),
+    target: path.join(expand(account.dir), rel),
+  };
+}
+
+/** Per-item status for an account (target side), plus the anchor source. */
+export function shareStatusFor(
+  label: string,
+): Record<ShareItemKey, ShareStatus & { source: string; target: string }> {
+  const out = {} as Record<
+    ShareItemKey,
+    ShareStatus & { source: string; target: string }
+  >;
+  for (const item of SHARE_ITEMS) {
+    const { source, target } = itemPathsFor(label, item);
+    out[item] = { ...getShareStatus(target), source, target };
+  }
+  return out;
+}
+
+export function shareFor(
+  label: string,
+  item: ShareItemKey,
+  mode: 'link' | 'copy',
+  entry?: string,
+): { backedUpTo?: string; source: string; target: string } {
+  const { source, target } = itemPathsFor(label, item, entry);
+  // Per-entry sharing needs the parent to be a REAL dir on the target side —
+  // if the whole dir is already linked, entries are implicitly shared.
+  if (entry) {
+    const parentState = getShareState(path.dirname(target));
+    if (parentState.kind === 'linked') {
+      throw new Error(
+        `The whole ${item} dir is already linked — per-entry sharing doesn't apply`,
+      );
+    }
+  }
+  return { ...shareItem(source, target, mode), source, target };
+}
+
+export function unshareFor(
+  label: string,
+  item: ShareItemKey,
+  opts: { restoreBackup?: boolean; keepCopy?: boolean } = {},
+  entry?: string,
+): { restoredFrom?: string; target: string } {
+  const { target } = itemPathsFor(label, item, entry);
+  return { ...unshareItem(target, opts), target };
+}
+
+export function syncSettingsFor(
+  label: string,
+  keys: string[],
+): { copied: string[]; missingInSource: string[] } {
+  const { account, anchor } = requireAccounts(label);
+  return syncSettingsKeys(
+    getSettingsPath(anchor),
+    getSettingsPath(account),
+    keys,
+  );
+}

--- a/src/electron-api.d.ts
+++ b/src/electron-api.d.ts
@@ -57,6 +57,7 @@ interface IElectronAPI {
         target: string;
       }
     >;
+    syncableKeys?: string[];
   }>;
   shareAccountItem: (
     label: string,

--- a/src/electron-api.d.ts
+++ b/src/electron-api.d.ts
@@ -68,6 +68,15 @@ interface IElectronAPI {
     item: string,
     opts: { restoreBackup?: boolean; keepCopy?: boolean },
   ) => Promise<{ ok: boolean; error?: string; restoredFrom?: string }>;
+  syncAccountSettings: (
+    label: string,
+    keys: string[],
+  ) => Promise<{
+    ok: boolean;
+    error?: string;
+    copied?: string[];
+    missingInSource?: string[];
+  }>;
   getBannerSeen: () => Promise<boolean>;
   setBannerSeen: () => void;
   invokeVSCode: (path: string, option: string) => void;

--- a/src/electron-api.d.ts
+++ b/src/electron-api.d.ts
@@ -40,6 +40,34 @@ interface IElectronAPI {
     changed?: boolean;
     path?: string;
   }>;
+  getAccountShareStatus: (label: string) => Promise<{
+    ok: boolean;
+    error?: string;
+    status?: Record<
+      'claude-md' | 'skills' | 'commands',
+      {
+        state: {
+          kind: 'none' | 'own' | 'linked' | 'broken-link' | 'mixed';
+          to?: string;
+          linked?: string[];
+          own?: string[];
+        };
+        backups: string[];
+        source: string;
+        target: string;
+      }
+    >;
+  }>;
+  shareAccountItem: (
+    label: string,
+    item: string,
+    mode: 'link' | 'copy',
+  ) => Promise<{ ok: boolean; error?: string; backedUpTo?: string }>;
+  unshareAccountItem: (
+    label: string,
+    item: string,
+    opts: { restoreBackup?: boolean; keepCopy?: boolean },
+  ) => Promise<{ ok: boolean; error?: string; restoredFrom?: string }>;
   getBannerSeen: () => Promise<boolean>;
   setBannerSeen: () => void;
   invokeVSCode: (path: string, option: string) => void;

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,6 +44,7 @@ import {
   SessionStatus,
 } from './session-status-hooks';
 import * as accountManager from './cli/account-manager';
+import * as shareManager from './cli/share-manager';
 import { invalidateAccountsCache } from './accounts';
 import {
   deleteRecentProjectRecord,
@@ -737,6 +738,52 @@ ipcMain.handle('accounts-set-default', (_event, label: string) => {
     return { ok: false, error: (error as Error).message };
   }
 });
+
+// --- cross-account sharing (Batch 3) — thin wrappers over share-manager ---
+ipcMain.handle('accounts-share-status', (_event, label: string) => {
+  try {
+    return { ok: true, status: shareManager.shareStatusFor(label) };
+  } catch (error) {
+    return { ok: false, error: (error as Error).message };
+  }
+});
+
+ipcMain.handle(
+  'accounts-share',
+  (_event, label: string, item: string, mode: 'link' | 'copy') => {
+    try {
+      const r = shareManager.shareFor(
+        label,
+        item as shareManager.ShareItemKey,
+        mode,
+      );
+      return { ok: true, backedUpTo: r.backedUpTo };
+    } catch (error) {
+      return { ok: false, error: (error as Error).message };
+    }
+  },
+);
+
+ipcMain.handle(
+  'accounts-unshare',
+  (
+    _event,
+    label: string,
+    item: string,
+    opts: { restoreBackup?: boolean; keepCopy?: boolean },
+  ) => {
+    try {
+      const r = shareManager.unshareFor(
+        label,
+        item as shareManager.ShareItemKey,
+        opts || {},
+      );
+      return { ok: true, restoredFrom: r.restoredFrom };
+    } catch (error) {
+      return { ok: false, error: (error as Error).message };
+    }
+  },
+);
 
 ipcMain.handle(
   'accounts-shell-hook',

--- a/src/main.ts
+++ b/src/main.ts
@@ -742,7 +742,13 @@ ipcMain.handle('accounts-set-default', (_event, label: string) => {
 // --- cross-account sharing (Batch 3) — thin wrappers over share-manager ---
 ipcMain.handle('accounts-share-status', (_event, label: string) => {
   try {
-    return { ok: true, status: shareManager.shareStatusFor(label) };
+    return {
+      ok: true,
+      status: shareManager.shareStatusFor(label),
+      // Single source of truth for the UI's sync buttons — keeps the
+      // renderer from drifting when the allowlist changes.
+      syncableKeys: [...shareManager.SYNCABLE_SETTINGS_KEYS],
+    };
   } catch (error) {
     return { ok: false, error: (error as Error).message };
   }
@@ -793,6 +799,9 @@ ipcMain.handle(
   'accounts-sync-settings',
   (_event, label: string, keys: string[]) => {
     try {
+      if (!Array.isArray(keys)) {
+        return { ok: false, error: 'keys must be an array' };
+      }
       const r = shareManager.syncSettingsFor(label, keys);
       return { ok: true, copied: r.copied, missingInSource: r.missingInSource };
     } catch (error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -752,6 +752,10 @@ ipcMain.handle(
   'accounts-share',
   (_event, label: string, item: string, mode: 'link' | 'copy') => {
     try {
+      // A malformed payload must fail, not silently fork a copy.
+      if (mode !== 'link' && mode !== 'copy') {
+        return { ok: false, error: `Unknown share mode "${String(mode)}"` };
+      }
       const r = shareManager.shareFor(
         label,
         item as shareManager.ShareItemKey,

--- a/src/main.ts
+++ b/src/main.ts
@@ -790,6 +790,18 @@ ipcMain.handle(
 );
 
 ipcMain.handle(
+  'accounts-sync-settings',
+  (_event, label: string, keys: string[]) => {
+    try {
+      const r = shareManager.syncSettingsFor(label, keys);
+      return { ok: true, copied: r.copied, missingInSource: r.missingInSource };
+    } catch (error) {
+      return { ok: false, error: (error as Error).message };
+    }
+  },
+);
+
+ipcMain.handle(
   'accounts-shell-hook',
   (_event, action: 'install' | 'uninstall') => {
     try {

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -132,6 +132,14 @@ const PopupDefaultExample = ({
   type ShareStatusMap = Record<'claude-md' | 'skills' | 'commands', ShareEntry>;
   const [sharingLabel, setSharingLabel] = useState<string | null>(null);
   const [shareStatus, setShareStatus] = useState<ShareStatusMap | null>(null);
+  // Delivered by the share-status IPC (single source of truth in the
+  // engine's allowlist) — the fallback only covers the pre-response render.
+  const [syncableKeys, setSyncableKeys] = useState<string[]>([
+    'statusLine',
+    'model',
+    'effortLevel',
+    'theme',
+  ]);
   const [accountsBusy, setAccountsBusy] = useState(false);
   // Footer example uses a REAL account name (prefer a non-default one) so
   // nobody reads it as a fixed keyword; the example clause is hidden entirely
@@ -268,6 +276,7 @@ const PopupDefaultExample = ({
       if (shareReqRef.current !== label) return; // stale response
       if (r.ok) {
         setShareStatus(r.status || null);
+        if (r.syncableKeys?.length) setSyncableKeys(r.syncableKeys);
       } else {
         setShareStatus(null);
         setAccountsError(r.error || 'Failed to load sharing status');
@@ -1233,9 +1242,7 @@ const PopupDefaultExample = ({
                         </span>
                       </span>
                       <span style={{ display: 'flex', gap: '6px' }}>
-                        {(
-                          ['statusLine', 'model', 'effortLevel', 'theme'] as const
-                        ).map((k) => (
+                        {syncableKeys.map((k) => (
                           <button
                             key={k}
                             style={smallButtonStyle}

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -1029,7 +1029,7 @@ const PopupDefaultExample = ({
                           disabled={accountsBusy}
                           title="Share the anchor's CLAUDE.md / skills / commands with this account"
                         >
-                          Sharing {sharingLabel === a.label ? '▾' : '▸'}
+                              Sharing {sharingLabel === a.label ? '▾' : '▸'}
                         </button>
                       )}
                       <button

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -1,7 +1,7 @@
 /** Enhanced popup menu for working folder selection and app settings */
 import Button from '@atlaskit/button';
 import Popup from '@atlaskit/popup';
-import { Fragment, useEffect, useState } from 'react';
+import { Fragment, useEffect, useRef, useState } from 'react';
 import { closeAppClick, openFolderSelector } from './switcher-ui';
 
 // Brand color theme matching app.tsx
@@ -257,9 +257,15 @@ const PopupDefaultExample = ({
     });
   };
 
+  // Guards rapid toggling between accounts: a stale response for a
+  // previously-requested label must not render under the current panel.
+  const shareReqRef = useRef<string | null>(null);
+
   const loadShareStatus = async (label: string) => {
+    shareReqRef.current = label;
     try {
       const r = await window.electronAPI.getAccountShareStatus(label);
+      if (shareReqRef.current !== label) return; // stale response
       if (r.ok) {
         setShareStatus(r.status || null);
       } else {
@@ -267,6 +273,7 @@ const PopupDefaultExample = ({
         setAccountsError(r.error || 'Failed to load sharing status');
       }
     } catch (e) {
+      if (shareReqRef.current !== label) return;
       setShareStatus(null);
       setAccountsError((e as Error).message);
     }

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -348,6 +348,22 @@ const PopupDefaultExample = ({
     });
   };
 
+  const handleSyncSetting = (label: string, key: string) => {
+    runAccountOp(async () => {
+      const r = await window.electronAPI.syncAccountSettings(label, [key]);
+      if (r.ok) {
+        setAccountsNotice(
+          r.copied && r.copied.length
+            ? `Copied ${key} from the anchor — applies to NEW sessions of "${label}".`
+            : `${key} is not set on the anchor — nothing to copy.`,
+        );
+      } else {
+        setAccountsNotice('');
+        setAccountsError(r.error || 'Sync failed');
+      }
+    });
+  };
+
   const handleSetDefaultAccount = (label: string) => {
     runAccountOp(async () => {
       const r = await window.electronAPI.setDefaultAccount(label);
@@ -1191,6 +1207,44 @@ const PopupDefaultExample = ({
                         );
                       },
                     )}
+                  {shareStatus && (
+                    <div
+                      style={{
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        alignItems: 'center',
+                        padding: '3px 0',
+                      }}
+                    >
+                      <span style={{ fontSize: '12px', color: '#ccc' }}>
+                        settings
+                        <span
+                          style={{
+                            color: '#777',
+                            marginLeft: '8px',
+                            fontSize: '11px',
+                          }}
+                        >
+                          copy a key from the anchor (one-time)
+                        </span>
+                      </span>
+                      <span style={{ display: 'flex', gap: '6px' }}>
+                        {(
+                          ['statusLine', 'model', 'effortLevel', 'theme'] as const
+                        ).map((k) => (
+                          <button
+                            key={k}
+                            style={smallButtonStyle}
+                            onClick={() => handleSyncSetting(a.label, k)}
+                            disabled={accountsBusy}
+                            title={`Copy the anchor's ${k} into this account's settings.json`}
+                          >
+                            {k}
+                          </button>
+                        ))}
+                      </span>
+                    </div>
+                  )}
                 </div>
               )}
               </Fragment>

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -303,12 +303,16 @@ const PopupDefaultExample = ({
 
   useEffect(() => {
     const onFocus = () => {
-      if (sharingLabel) loadShareStatus(sharingLabel);
+      // Only while the panel is actually visible — hidden focus events must
+      // not fire IPC or surface errors outside the Accounts tab.
+      if (isOpen && settingsTab === 'accounts' && sharingLabel) {
+        loadShareStatus(sharingLabel);
+      }
     };
     window.addEventListener('focus', onFocus);
     return () => window.removeEventListener('focus', onFocus);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sharingLabel]);
+  }, [isOpen, settingsTab, sharingLabel]);
 
   const handleShare = (label: string, item: string, mode: 'link' | 'copy') => {
     runAccountOp(async () => {

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -287,8 +287,28 @@ const PopupDefaultExample = ({
     }
     setSharingLabel(label);
     setShareStatus(null);
-    loadShareStatus(label);
+    // loading is owned by the effects below (open + focus refresh)
   };
+
+  // Own the panel's freshness: load on open, and RE-load when the window
+  // regains focus — the user may have changed the underlying files from a
+  // terminal (e.g. echo > CLAUDE.md) while the panel sat open. (User-reported:
+  // the panel showed a stale state until an app restart.)
+  useEffect(() => {
+    if (isOpen && settingsTab === 'accounts' && sharingLabel) {
+      loadShareStatus(sharingLabel);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, settingsTab, sharingLabel]);
+
+  useEffect(() => {
+    const onFocus = () => {
+      if (sharingLabel) loadShareStatus(sharingLabel);
+    };
+    window.addEventListener('focus', onFocus);
+    return () => window.removeEventListener('focus', onFocus);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sharingLabel]);
 
   const handleShare = (label: string, item: string, mode: 'link' | 'copy') => {
     runAccountOp(async () => {
@@ -1009,7 +1029,7 @@ const PopupDefaultExample = ({
                           disabled={accountsBusy}
                           title="Share the anchor's CLAUDE.md / skills / commands with this account"
                         >
-                          Sharing
+                          Sharing {sharingLabel === a.label ? '▾' : '▸'}
                         </button>
                       )}
                       <button

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -1,7 +1,7 @@
 /** Enhanced popup menu for working folder selection and app settings */
 import Button from '@atlaskit/button';
 import Popup from '@atlaskit/popup';
-import { useEffect, useState } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 import { closeAppClick, openFolderSelector } from './switcher-ui';
 
 // Brand color theme matching app.tsx
@@ -116,6 +116,22 @@ const PopupDefaultExample = ({
   const [anchorNameInput, setAnchorNameInput] = useState('');
   const [renamingLabel, setRenamingLabel] = useState<string | null>(null);
   const [renameInput, setRenameInput] = useState('');
+  // Cross-account sharing panel (Batch 3): which account's panel is open +
+  // its per-item status from the share engine.
+  type ShareEntry = {
+    state: {
+      kind: 'none' | 'own' | 'linked' | 'broken-link' | 'mixed';
+      to?: string;
+      linked?: string[];
+      own?: string[];
+    };
+    backups: string[];
+    source: string;
+    target: string;
+  };
+  type ShareStatusMap = Record<'claude-md' | 'skills' | 'commands', ShareEntry>;
+  const [sharingLabel, setSharingLabel] = useState<string | null>(null);
+  const [shareStatus, setShareStatus] = useState<ShareStatusMap | null>(null);
   const [accountsBusy, setAccountsBusy] = useState(false);
   // Footer example uses a REAL account name (prefer a non-default one) so
   // nobody reads it as a fixed keyword; the example clause is hidden entirely
@@ -237,6 +253,70 @@ const PopupDefaultExample = ({
       } else {
         setAccountsNotice('');
         setAccountsError(r.error || 'Failed to rename');
+      }
+    });
+  };
+
+  const loadShareStatus = async (label: string) => {
+    try {
+      const r = await window.electronAPI.getAccountShareStatus(label);
+      if (r.ok) {
+        setShareStatus(r.status || null);
+      } else {
+        setShareStatus(null);
+        setAccountsError(r.error || 'Failed to load sharing status');
+      }
+    } catch (e) {
+      setShareStatus(null);
+      setAccountsError((e as Error).message);
+    }
+  };
+
+  const toggleSharing = (label: string) => {
+    if (sharingLabel === label) {
+      setSharingLabel(null);
+      setShareStatus(null);
+      return;
+    }
+    setSharingLabel(label);
+    setShareStatus(null);
+    loadShareStatus(label);
+  };
+
+  const handleShare = (label: string, item: string, mode: 'link' | 'copy') => {
+    runAccountOp(async () => {
+      const r = await window.electronAPI.shareAccountItem(label, item, mode);
+      if (r.ok) {
+        setAccountsNotice(
+          `${mode === 'link' ? 'Linked' : 'Copied'} ${item}${
+            r.backedUpTo ? ' (previous content backed up)' : ''
+          } — new sessions of "${label}" pick it up.`,
+        );
+        await loadShareStatus(label);
+      } else {
+        setAccountsNotice('');
+        setAccountsError(r.error || 'Share failed');
+      }
+    });
+  };
+
+  const handleUnshare = (
+    label: string,
+    item: string,
+    opts: { restoreBackup?: boolean },
+  ) => {
+    runAccountOp(async () => {
+      const r = await window.electronAPI.unshareAccountItem(label, item, opts);
+      if (r.ok) {
+        setAccountsNotice(
+          opts.restoreBackup
+            ? `Unlinked ${item} and restored the previous content.`
+            : `Unlinked ${item} — the source is untouched; Link again anytime.`,
+        );
+        await loadShareStatus(label);
+      } else {
+        setAccountsNotice('');
+        setAccountsError(r.error || 'Unshare failed');
       }
     });
   };
@@ -848,7 +928,8 @@ const PopupDefaultExample = ({
               </div>
             )}
             {accounts.map((a) => (
-              <div key={a.label} style={rowStyle}>
+              <Fragment key={a.label}>
+              <div style={rowStyle}>
                 <div style={{ display: 'flex', flexDirection: 'column' }}>
                   <span style={labelStyle} title={`Config dir: ${a.dir}`}>
                     {a.label}
@@ -908,6 +989,22 @@ const PopupDefaultExample = ({
                     </>
                   ) : (
                     <>
+                      {!a.isAnchor && (
+                        <button
+                          style={{
+                            ...smallButtonStyle,
+                            color:
+                              sharingLabel === a.label
+                                ? THEME.primary
+                                : smallButtonStyle.color,
+                          }}
+                          onClick={() => toggleSharing(a.label)}
+                          disabled={accountsBusy}
+                          title="Share the anchor's CLAUDE.md / skills / commands with this account"
+                        >
+                          Sharing
+                        </button>
+                      )}
                       <button
                         style={smallButtonStyle}
                         onClick={() => {
@@ -943,6 +1040,133 @@ const PopupDefaultExample = ({
                   )}
                 </div>
               </div>
+              {sharingLabel === a.label && (
+                <div style={{ padding: '0 16px 8px 28px' }}>
+                  <div
+                    style={{
+                      fontSize: '11px',
+                      color: THEME.text.secondary,
+                      paddingBottom: '4px',
+                    }}
+                  >
+                    Share from the anchor (~/.claude) — Link stays in sync;
+                    Copy is an independent fork
+                  </div>
+                  {!shareStatus && (
+                    <div style={{ fontSize: '11px', color: '#777' }}>
+                      Loading…
+                    </div>
+                  )}
+                  {shareStatus &&
+                    (['claude-md', 'skills', 'commands'] as const).map(
+                      (item) => {
+                        const st = shareStatus[item];
+                        if (!st) return null;
+                        const tilde = (p: string) =>
+                          p.replace(/^\/Users\/[^/]+/, '~');
+                        const desc =
+                          st.state.kind === 'linked'
+                            ? `linked → ${tilde(st.state.to || '')}`
+                            : st.state.kind === 'broken-link'
+                              ? 'BROKEN link'
+                              : st.state.kind === 'mixed'
+                                ? `mixed (${st.state.linked?.length ?? 0} linked, ${st.state.own?.length ?? 0} own)`
+                                : st.state.kind === 'own'
+                                  ? 'own (not shared)'
+                                  : 'none';
+                        return (
+                          <div
+                            key={item}
+                            style={{
+                              display: 'flex',
+                              justifyContent: 'space-between',
+                              alignItems: 'center',
+                              padding: '3px 0',
+                            }}
+                          >
+                            <span style={{ fontSize: '12px', color: '#ccc' }}>
+                              {item}
+                              <span
+                                style={{
+                                  color: '#777',
+                                  marginLeft: '8px',
+                                  fontSize: '11px',
+                                }}
+                              >
+                                {desc}
+                              </span>
+                            </span>
+                            <span style={{ display: 'flex', gap: '6px' }}>
+                              {(st.state.kind === 'none' ||
+                                st.state.kind === 'own') && (
+                                <>
+                                  <button
+                                    style={smallButtonStyle}
+                                    onClick={() =>
+                                      handleShare(a.label, item, 'link')
+                                    }
+                                    disabled={accountsBusy}
+                                    title="Symlink to the anchor's copy (stays in sync; existing content is backed up first)"
+                                  >
+                                    Link
+                                  </button>
+                                  <button
+                                    style={smallButtonStyle}
+                                    onClick={() =>
+                                      handleShare(a.label, item, 'copy')
+                                    }
+                                    disabled={accountsBusy}
+                                    title="Copy the anchor's version as an independent fork"
+                                  >
+                                    Copy
+                                  </button>
+                                </>
+                              )}
+                              {(st.state.kind === 'linked' ||
+                                st.state.kind === 'broken-link') && (
+                                <>
+                                  <button
+                                    style={smallButtonStyle}
+                                    onClick={() =>
+                                      handleUnshare(a.label, item, {})
+                                    }
+                                    disabled={accountsBusy}
+                                    title="Remove the link — the anchor's copy is untouched"
+                                  >
+                                    Unlink
+                                  </button>
+                                  {st.backups.length > 0 && (
+                                    <button
+                                      style={smallButtonStyle}
+                                      onClick={() =>
+                                        handleUnshare(a.label, item, {
+                                          restoreBackup: true,
+                                        })
+                                      }
+                                      disabled={accountsBusy}
+                                      title="Remove the link AND restore the content this account had before sharing"
+                                    >
+                                      Unlink & restore
+                                    </button>
+                                  )}
+                                </>
+                              )}
+                              {st.state.kind === 'mixed' && (
+                                <span
+                                  style={{ fontSize: '10px', color: '#777' }}
+                                >
+                                  per-entry — manage via codev account share
+                                  --entry
+                                </span>
+                              )}
+                            </span>
+                          </div>
+                        );
+                      },
+                    )}
+                </div>
+              )}
+              </Fragment>
             ))}
 
             {accountsLoaded && accounts.length === 0 && (

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -25,6 +25,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     item: string,
     opts: { restoreBackup?: boolean; keepCopy?: boolean },
   ) => ipcRenderer.invoke('accounts-unshare', label, item, opts),
+  syncAccountSettings: (label: string, keys: string[]) =>
+    ipcRenderer.invoke('accounts-sync-settings', label, keys),
   getBannerSeen: () => ipcRenderer.invoke('get-banner-seen'),
   setBannerSeen: () => ipcRenderer.send('set-banner-seen'),
   invokeVSCode: (path: string, option: string) =>

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -16,6 +16,15 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('accounts-set-default', label),
   setAccountsShellHook: (action: 'install' | 'uninstall') =>
     ipcRenderer.invoke('accounts-shell-hook', action),
+  getAccountShareStatus: (label: string) =>
+    ipcRenderer.invoke('accounts-share-status', label),
+  shareAccountItem: (label: string, item: string, mode: 'link' | 'copy') =>
+    ipcRenderer.invoke('accounts-share', label, item, mode),
+  unshareAccountItem: (
+    label: string,
+    item: string,
+    opts: { restoreBackup?: boolean; keepCopy?: boolean },
+  ) => ipcRenderer.invoke('accounts-unshare', label, item, opts),
   getBannerSeen: () => ipcRenderer.invoke('get-banner-seen'),
   setBannerSeen: () => ipcRenderer.send('set-banner-seen'),
   invokeVSCode: (path: string, option: string) =>


### PR DESCRIPTION
## Summary

**Batch 3: cross-account sharing** — share the anchor account's global files (`CLAUDE.md` / `skills/` / `commands/`) with other accounts, per item: **Link** (symlink, stays in sync) / **Copy** (independent fork) / skip. Engine + CLI + UI in one PR (per discussion, so it's testable end-to-end from the UI).

Depends on #129 (the `isAnchor` refactor — merged). Sharing mechanism was verified live earlier (Claude Code follows symlinks for skills entries, whole dirs, and CLAUDE.md; this machine has been running on hand-made links since).

## Semantics (the part worth reviewing carefully)

- **Never silently overwrite**: sharing over an account's own real file/dir first renames it to a timestamped `.codev-bak-*` sibling (never `ln -sf`). An existing symlink is just replaced (a pointer needs no backup).
- **Unshare is reversible by construction**:
  - plain **Unlink** — zero data loss (removes a pointer; the anchor's copy is untouched; re-link anytime)
  - **Unlink & restore** (`--restore-backup`) — true undo: brings back the content the account had before sharing
  - `--keep-copy` — materializes the shared content as an independent fork
- **Status engine** distinguishes `none` / `own` / `linked → target` / `broken-link` / `mixed` (a real dir containing per-entry links) — and correctly recognizes pre-existing hand-made links it didn't create.
- **`sync-settings`** copies `statusLine` / `model` / `effortLevel` / `theme` from the anchor (`settings.json` keys). Hooks (installed per-dir by CodeV), `enabledPlugins`, and `permissions` are deliberately excluded.
- **`plugins/` is NOT shareable** — experiment result: it's a per-account install registry (`installed_plugins.json` with absolute `installPath`s) + caches, i.e. mutable state, not payload. Same exclusion class as session data.

## What's included

- `src/cli/share-manager.ts` — path-based engine (tmpdir-testable) + registry-aware wrappers
- CLI: `codev account share <name>` (status), `share <name> <item> --link|--copy [--entry E]`, `unshare <name> <item> [--restore-backup|--keep-copy]`, `sync-settings <name> <key...>`; tab completion for all of it
- UI: **Sharing** button per non-anchor account row → inline panel (per-item status + Link / Copy / Unlink / Unlink & restore; `mixed` dirs point at the CLI's `--entry`)
- IPC trio (`accounts-share-status/share/unshare`) as thin wrappers
- 12 real-fs integration tests under `os.tmpdir()` (32 total)

## Also added during review/testing

- **Settings-key sync in the UI** (user request): the Sharing panel gains a `settings` row with one-click buttons — `statusLine` (the headline case) / `model` / `effortLevel` / `theme` — each copies that key from the anchor with copied/missing feedback.
- **Panel freshness** (user-reported: stale state persisted until an app restart): share status reloads when the Accounts tab reopens **and when the window regains focus** (the natural flow after editing files in a terminal), gated to fire only while the panel is visible.
- **`Sharing ▸/▾` disclosure arrow** (user feedback: the button read as a one-shot action, not an expander).
- **Hardening from the review rounds**: unshare validates the restore-backup/keep-copy source *before* unlinking (a failed undo can't half-remove the share); keep-copy stages to a **unique temp sibling first** (no TOCTOU window, no stale-temp contamination); backup names uniquified beyond 1s timestamp precision; CLI rejects ambiguous `--link --copy` and the IPC validates the mode; entry names starting with `-` fail early; malformed `settings.json` errors include the path; popup ignores stale share-status responses when rapidly switching accounts.
- Deferred with rationale (on the threads): renderer tilde helper stays regex-based (macOS-only app; no `os` in the renderer); typing preload against `IElectronAPI` needs the d.ts to become a module first — its own tiny refactor.

## How to test (UI, needs `yarn make`)

1. Settings → Accounts → **Sharing** on the `work` row → panel should show your existing hand-made links: all three items `linked → ~/.claude/...` (the engine recognizing state it didn't create).
2. **Unlink** `commands` → status `none`; check `~/.claude/commands` still exists (source untouched). **Link** it back → `linked` again.
3. Fork test: **Unlink** an item then **Copy** it → status `own (not shared)`; editing the copy won't touch the anchor's version. (Restore to Link afterwards.)
4. Backup/undo test: `echo test > ~/.claude-work/CLAUDE.md` after unlinking claude-md → panel shows `own` → **Link** (notice mentions backup) → **Unlink & restore** → your `test` content is back.
5. CLI spot-check: `yarn account share work` (status table), `yarn account sync-settings work model` (copies your anchor's model setting), `claude w<TAB>` still completes.
6. Settings row: in the Sharing panel click **statusLine** → notice `Copied statusLine from the anchor…`.
7. Freshness: with the panel open, change a target from a terminal (e.g. `rm`/`echo` on `~/.claude-work/CLAUDE.md`) → cmd-tab back to CodeV → the row updates without restarting.

`tsc --noEmit` 0 errors; `yarn test` 35/35 (14 real-fs engine tests).

## Notes

- Per-entry sharing (`--entry <skill-name>`) is CLI-only in this PR; the UI shows `mixed` state and defers to the CLI. UI per-entry management can come later if wanted.
- Backlog after this: #127 (detect existing config dirs + one-click register), #128 (copy-fork resume), #121 (VS Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cross-account sharing and one-click settings sync so non-anchor accounts can reuse the anchor’s global `CLAUDE.md`, `skills/`, and `commands/`. Includes the engine, CLI, UI, and docs updates for end-to-end testing; version 1.0.82.

- New Features
  - Path-based share engine with clear status: none / own / linked → target / broken-link / mixed (recognizes hand-made links).
  - Safe by default: never overwrite; own content backed up to `.codev-bak-<ts>`; Unlink is lossless; Unlink & restore truly undoes; `--keep-copy` materializes a fork via a unique temp.
  - CLI: `codev account share <name>` (status), `share <name> <item> --link|--copy [--entry E]`, `unshare <name> <item> [--entry E] [--restore-backup|--keep-copy]`, `sync-settings <name> <key...>`; completion for labels/items/keys.
  - UI: per-account Sharing panel with per-item status and actions (Link/Copy/Unlink/Unlink & restore), plus per-key sync buttons for `statusLine`, `model`, `effortLevel`, `theme`; panel refreshes on Accounts tab reopen and when the window regains focus; `mixed` dirs point to the CLI.
  - `plugins/` not shareable (per-account install state). IPC endpoints for share status/share/unshare/sync-settings; UI renders syncable settings keys from the engine’s IPC allowlist. Real-fs integration tests cover the engine. README/design docs updated.

- Bug Fixes
  - Panel freshness: reload on reopen/focus; stale share-status responses ignored during rapid account switches.
  - Unshare validates restore-backup/keep-copy before unlinking; backup names uniquified; `--keep-copy` copies to a unique temp before unlinking (no TOCTOU).
  - CLI/IPC validation: reject ambiguous `--link --copy`; validate mode; early-reject `--entry` names starting with `-`; settings JSON errors show the path; `accounts-sync-settings` validates `keys` is an array.

<sup>Written for commit f1b793c8010877130f5418238c5413fa7611c4f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/grimmerk/codev/pull/130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cross-account sharing for Claude settings, skills, and commands (link for sync or copy for independence).
  * Added per-item Sharing controls in the Accounts view, including link/copy, unlink, and optional “unlink & restore” using recoverable backups.
  * Extended the CLI with `codev account` subcommands: `share`, `unshare`, and `sync-settings` (syncs an allowlisted set of settings keys).
* **Bug Fixes**
  * Improved protection against overwriting by creating recoverable backups and supporting restore/keep-copy outcomes.
* **Documentation**
  * Updated the changelog and multi-account support documentation with the new UI/CLI behavior.
* **Chores**
  * Released version 1.0.82.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
